### PR TITLE
groups now reflect remote members (who have communication addresses)

### DIFF
--- a/cmd/testnode.go
+++ b/cmd/testnode.go
@@ -52,7 +52,6 @@ var ecdsaHexKeys = []string{
 
 var BlsSignKeys []*bls.SignKey
 var EcdsaKeys []*ecdsa.PrivateKey
-var TestNetPublicKeys []consensus.PublicKey
 var TestNetGroup *consensus.Group
 
 func init() {
@@ -71,12 +70,12 @@ func init() {
 		EcdsaKeys[i] = key
 	}
 
-	TestNetPublicKeys = make([]consensus.PublicKey, len(BlsSignKeys))
+	members := make([]*consensus.RemoteNode, len(BlsSignKeys))
 	for i, key := range BlsSignKeys {
-		TestNetPublicKeys[i] = consensus.BlsKeyToPublicKey(key.MustVerKey())
+		members[i] = consensus.NewRemoteNode(consensus.BlsKeyToPublicKey(key.MustVerKey()), consensus.EcdsaToPublicKey(&EcdsaKeys[i].PublicKey))
 	}
 
-	TestNetGroup = consensus.GroupFromPublicKeys(TestNetPublicKeys)
+	TestNetGroup = consensus.NewGroup(members)
 }
 
 var nodeIndex int

--- a/consensus/networkedclient.go
+++ b/consensus/networkedclient.go
@@ -35,10 +35,10 @@ func NewNetworkedClient(group *Group) (*NetworkedClient, error) {
 
 	return &NetworkedClient{
 		sessionKey: sessionKey,
-		Client:     network.NewMessageHandler(node, []byte(group.Id)),
+		Client:     network.NewMessageHandler(node, []byte(group.Id())),
 		Group:      group,
-		topic:      []byte(group.Id),
-		symkey:     crypto.Keccak256([]byte(group.Id)),
+		topic:      []byte(group.Id()),
+		symkey:     crypto.Keccak256([]byte(group.Id())),
 	}, nil
 }
 

--- a/consensus/networkedclient_integration_test.go
+++ b/consensus/networkedclient_integration_test.go
@@ -22,8 +22,11 @@ func TestNetworkedClient_AddBlock(t *testing.T) {
 
 	ecdsaKey, err := crypto.GenerateKey()
 	assert.Nil(t, err)
+	dstPubKey := consensus.EcdsaToPublicKey(&ecdsaKey.PublicKey)
 
-	group := consensus.GroupFromPublicKeys([]consensus.PublicKey{pubKey})
+	rn := consensus.NewRemoteNode(pubKey, dstPubKey)
+
+	group := consensus.NewGroup([]*consensus.RemoteNode{rn})
 
 	store := storage.NewMemStorage()
 
@@ -97,8 +100,11 @@ func BenchmarkNetworkedClient_AddBlock(b *testing.B) {
 
 	ecdsaKey, err := crypto.GenerateKey()
 	assert.Nil(b, err)
+	dstPubKey := consensus.EcdsaToPublicKey(&ecdsaKey.PublicKey)
 
-	group := consensus.GroupFromPublicKeys([]consensus.PublicKey{pubKey})
+	rn := consensus.NewRemoteNode(pubKey, dstPubKey)
+
+	group := consensus.NewGroup([]*consensus.RemoteNode{rn})
 
 	store := storage.NewMemStorage()
 

--- a/network/node_integration_test.go
+++ b/network/node_integration_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestNode_Integration(t *testing.T) {
+	testTopic := []byte("nodeIntegration")
+
 	listenerKey, err := crypto.GenerateKey()
 	assert.Nil(t, err)
 
@@ -28,8 +30,8 @@ func TestNode_Integration(t *testing.T) {
 	client.Start()
 	defer client.Stop()
 
-	topicSub := listener.SubscribeToTopic(TestTopic, TestKey)
-	keySub := listener.SubscribeToKey(clientKey)
+	topicSub := listener.SubscribeToTopic(testTopic, TestKey)
+	keySub := listener.SubscribeToKey(listenerKey)
 
 	req := Request{
 		Type:    "PING",
@@ -44,7 +46,7 @@ func TestNode_Integration(t *testing.T) {
 	}
 
 	params := MessageParams{
-		Topic:    TestTopic,
+		Topic:    testTopic,
 		KeySym:   TestKey,
 		PoW:      0.1,
 		WorkTime: 2,
@@ -62,8 +64,8 @@ func TestNode_Integration(t *testing.T) {
 	assert.Nil(t, err)
 
 	err = client.Send(MessageParams{
-		Topic:    TestTopic,
-		Dst:      &clientKey.PublicKey,
+		Topic:    testTopic,
+		Dst:      &listenerKey.PublicKey,
 		PoW:      0.1,
 		WorkTime: 10,
 		Payload:  []byte("hiKey"),

--- a/signer/networkedsigner.go
+++ b/signer/networkedsigner.go
@@ -17,7 +17,7 @@ type NetworkedSigner struct {
 }
 
 func NewNetworkedSigner(node *network.Node, signer *Signer) *NetworkedSigner {
-	handler := network.NewMessageHandler(node, []byte(signer.Group.Id))
+	handler := network.NewMessageHandler(node, []byte(signer.Group.Id()))
 
 	ns := &NetworkedSigner{
 		Node:   node,
@@ -86,7 +86,7 @@ func (ns *NetworkedSigner) TipHandler(req network.Request) (*network.Response, e
 func (ns *NetworkedSigner) Start() {
 	ns.Node.Start()
 	ns.Server.Start()
-	ns.Server.HandleTopic([]byte(ns.Signer.Group.Id), crypto.Keccak256([]byte(ns.Signer.Group.Id)))
+	ns.Server.HandleTopic([]byte(ns.Signer.Group.Id()), crypto.Keccak256([]byte(ns.Signer.Group.Id())))
 }
 
 func (ns *NetworkedSigner) Stop() {

--- a/signer/networkedsigner_integration_test.go
+++ b/signer/networkedsigner_integration_test.go
@@ -26,7 +26,7 @@ func TestIntegrationNetworkedSigner(t *testing.T) {
 	ecdsaKey, err := crypto.GenerateKey()
 	assert.Nil(t, err)
 
-	group := consensus.GroupFromPublicKeys([]consensus.PublicKey{pubKey})
+	group := consensus.NewGroup([]*consensus.RemoteNode{consensus.NewRemoteNode(pubKey, consensus.EcdsaToPublicKey(&ecdsaKey.PublicKey))})
 
 	store := storage.NewMemStorage()
 
@@ -48,7 +48,7 @@ func TestIntegrationNetworkedSigner(t *testing.T) {
 	sessionKey, err := crypto.GenerateKey()
 	assert.Nil(t, err)
 
-	client := network.NewMessageHandler(network.NewNode(sessionKey), []byte(group.Id))
+	client := network.NewMessageHandler(network.NewNode(sessionKey), []byte(group.Id()))
 
 	client.Start()
 	defer client.Stop()
@@ -93,7 +93,7 @@ func TestIntegrationNetworkedSigner(t *testing.T) {
 
 	req, err := network.BuildRequest(consensus.MessageType_AddBlock, addBlockRequest)
 
-	respChan, err := client.Broadcast([]byte(group.Id), crypto.Keccak256([]byte(group.Id)), req)
+	respChan, err := client.Broadcast([]byte(group.Id()), crypto.Keccak256([]byte(group.Id())), req)
 	assert.Nil(t, err)
 
 	resp := <-respChan

--- a/signer/signer_test.go
+++ b/signer/signer_test.go
@@ -16,9 +16,12 @@ func createSigner(t *testing.T) *Signer {
 	assert.Nil(t, err)
 
 	pubKey := consensus.BlsKeyToPublicKey(key.MustVerKey())
-	group := &consensus.Group{
-		SortedPublicKeys: []consensus.PublicKey{pubKey},
-	}
+
+	dstKey, err := crypto.GenerateKey()
+	assert.Nil(t, err)
+	dstPubKey := consensus.EcdsaToPublicKey(&dstKey.PublicKey)
+
+	group := consensus.NewGroup([]*consensus.RemoteNode{consensus.NewRemoteNode(pubKey, dstPubKey)})
 
 	store := storage.NewMemStorage()
 


### PR DESCRIPTION
This is another learning from the gossip work. It changes a notary group from just being a collection of signing keys to a collection of signing keys *and* destination keys for communication work (when you need to talk to just a single node).