### PR TITLE
Add validator to ensure block's PreviousTip matches stored Tip

### DIFF
--- a/signer/signer.go
+++ b/signer/signer.go
@@ -55,6 +55,7 @@ func (s *Signer) ProcessAddBlock(req *consensus.AddBlockRequest) (*consensus.Add
 	chainTree, err := chaintree.NewChainTree(
 		tree,
 		[]chaintree.BlockValidatorFunc{
+			s.IsNextBlock,
 			s.IsOwner,
 		},
 		consensus.DefaultTransactors,


### PR DESCRIPTION
While being completely lost in the tupelo forest, @tobowers came and helped me, at which point we discovered this bug. Before this change, you could have a block be processed that referenced an old tip inside that same chaintree, wiping out the changes since then. This fixes that by adding a new validator that ensures the block's PreviousTip matches the current stored Tip.

