### PR TITLE
allow async response to requests in the message handler

### DIFF
--- a/network/messagehandler_integration_test.go
+++ b/network/messagehandler_integration_test.go
@@ -29,11 +29,11 @@ func TestClient_DoRequest(t *testing.T) {
 	clientNode.Start()
 	defer serverNode.Stop()
 
-	reqHandler := func(req Request) (*Response, error) {
-		resp := &Response{
+	reqHandler := func(req Request, respChan ResponseChan) error {
+		respChan <- &Response{
 			Payload: req.Payload,
 		}
-		return resp, nil
+		return nil
 	}
 
 	server := NewMessageHandler(serverNode, TestTopic)
@@ -76,11 +76,11 @@ func TestClient_Broadcast(t *testing.T) {
 	clientNode.Start()
 	defer serverNode.Stop()
 
-	reqHandler := func(req Request) (*Response, error) {
-		resp := &Response{
+	reqHandler := func(req Request, respChan ResponseChan) error {
+		respChan <- &Response{
 			Payload: req.Payload,
 		}
-		return resp, nil
+		return nil
 	}
 
 	server := NewMessageHandler(serverNode, TestTopic)


### PR DESCRIPTION
This is a relatively straight forward change that allows for asynchronous response. This will be useful in gossip and is actually more convenient for building things like middleware, etc.