### PR TITLE
lock ethereum and chaintree versions

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,13 +10,13 @@
   branch = "master"
   name = "github.com/aristanetworks/goarista"
   packages = ["monotime"]
-  revision = "c41ed3986faaeb0aeed2bd98e92468f8ea317954"
+  revision = "3e95f038af02770089c3988f48f9e1a6b6fe2ac5"
 
 [[projects]]
   branch = "master"
   name = "github.com/btcsuite/btcd"
   packages = ["btcec"]
-  revision = "2be2f12b358dc57d70b8f501b00be450192efbc3"
+  revision = "9a2f9524024889e129a5422aca2cff73cb3eabf6"
 
 [[projects]]
   name = "github.com/chzyer/readline"
@@ -39,7 +39,6 @@
   name = "github.com/ethereum/go-ethereum"
   packages = ["common","common/hexutil","common/math","common/mclock","crypto","crypto/ecies","crypto/secp256k1","crypto/sha3","event","log","metrics","p2p","p2p/discover","p2p/discv5","p2p/nat","p2p/netutil","rlp","rpc","whisper/whisperv6"]
   revision = "1e67410e88d2685bc54611a7c9f75c327b553ccc"
-  version = "v1.8.1"
 
 [[projects]]
   name = "github.com/fatih/color"
@@ -69,7 +68,7 @@
   branch = "master"
   name = "github.com/golang/snappy"
   packages = ["."]
-  revision = "553a641470496b2327abcac10b36396bd98e45c9"
+  revision = "2e65f85255dbc3072edf28d6b5b8efc472979f5a"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -93,7 +92,7 @@
   branch = "master"
   name = "github.com/huin/goupnp"
   packages = [".","dcps/internetgateway1","dcps/internetgateway2","httpu","scpd","soap","ssdp"]
-  revision = "dceda08e705b2acee36aab47d765ed801f64cfc7"
+  revision = "1395d1447324cbea88d249fbfcfd70ea878fdfca"
 
 [[projects]]
   name = "github.com/inconshreveable/mousetrap"
@@ -102,34 +101,34 @@
   version = "v1.0"
 
 [[projects]]
-  branch = "master"
   name = "github.com/ipfs/go-block-format"
   packages = ["."]
-  revision = "9a467d476a676d8318b19993ab40067c5d75af28"
+  revision = "6dead782393dde60414a65a32eb4fcc238db8e8c"
+  version = "v0.1.8"
 
 [[projects]]
-  branch = "master"
   name = "github.com/ipfs/go-cid"
   packages = ["."]
-  revision = "078355866b1dda1658b5fdc5496ed7e25fdcf883"
+  revision = "5b04f3043387b02aeeee6a35899f0e767bae3b33"
+  version = "v0.7.21"
 
 [[projects]]
-  branch = "master"
   name = "github.com/ipfs/go-ipfs-util"
   packages = ["."]
-  revision = "9ed527918c2f20abdf0adfab0553cd87db34f656"
+  revision = "10d786c5ed859afd22223df76a89bf57b24b2ee1"
+  version = "v1.2.8"
 
 [[projects]]
   branch = "refmt"
   name = "github.com/ipfs/go-ipld-cbor"
   packages = ["."]
-  revision = "8b666bca090899848849a507a008080db0fcfe21"
+  revision = "ab2a510fdde7b8b9277be778f8d661f1f62bb62d"
 
 [[projects]]
-  branch = "master"
   name = "github.com/ipfs/go-ipld-format"
   packages = ["."]
-  revision = "9b90054a0e154f2c07fe03e820ba221de79992b0"
+  revision = "6b4c9ea0f786788f3ee4e458ca39bb3f4da2ee71"
+  version = "v0.5.4"
 
 [[projects]]
   name = "github.com/jackpal/go-nat-pmp"
@@ -140,8 +139,8 @@
 [[projects]]
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
-  version = "v1.7.6"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -171,37 +170,37 @@
   branch = "master"
   name = "github.com/mitchellh/go-homedir"
   packages = ["."]
-  revision = "b8bc1bf767474819792c23f32d8286a45736f1c6"
+  revision = "3864e76763d94a6df2f9960b16a20a33da9f9a66"
 
 [[projects]]
   branch = "master"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
   branch = "master"
   name = "github.com/mr-tron/base58"
   packages = ["base58"]
-  revision = "c1bdf7c52f59d6685ca597b9955a443ff95eeee6"
+  revision = "4df4dc6e86a912614d09719d10cad427b087cbfb"
 
 [[projects]]
-  branch = "master"
   name = "github.com/multiformats/go-multibase"
   packages = ["."]
   revision = "dfd5076869faca5aed2886dcba60b44a0d0e9c01"
+  version = "v0.2.6"
 
 [[projects]]
-  branch = "master"
   name = "github.com/multiformats/go-multihash"
   packages = ["."]
-  revision = "265e72146e710ff649c6982e3699d01d4e9a18bb"
+  revision = "8be2a682ab9f254311de1375145a2f78a809b07d"
+  version = "v1.0.8"
 
 [[projects]]
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
-  version = "v1.1.0"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
   name = "github.com/pmezard/go-difflib"
@@ -213,25 +212,24 @@
   branch = "master"
   name = "github.com/polydawn/refmt"
   packages = ["cbor","obj","obj/atlas","shared","tok"]
-  revision = "b0c505d9a8cea4460b8ac57691d4ce9381e1e264"
+  revision = "54ef854b7d9bc97e65cf6d8c8f7c8845107eaefe"
 
 [[projects]]
-  branch = "master"
   name = "github.com/quorumcontrol/chaintree"
   packages = ["chaintree","dag","typecaster"]
-  revision = "4928d1c88eb2c295d46b3574466a40bbd55dd14b"
+  revision = "a5b36259df6cd5b1f7867c58d0bd1b04ed128cc8"
 
 [[projects]]
   branch = "master"
   name = "github.com/rcrowley/go-metrics"
   packages = [".","exp"]
-  revision = "8732c616f52954686704c8645fe1a9d59e9df7c1"
+  revision = "e2704e165165ec55d062f5919b4b29494e9fa790"
 
 [[projects]]
   name = "github.com/rs/cors"
   packages = ["."]
-  revision = "feef513b9575b32f84bafa580aad89b011259019"
-  version = "v1.3.0"
+  revision = "3fb1b69b103a84de38a19c3c6ec073dd6caa4d3f"
+  version = "v1.5.0"
 
 [[projects]]
   name = "github.com/spaolacci/murmur3"
@@ -242,8 +240,8 @@
 [[projects]]
   name = "github.com/spf13/afero"
   packages = [".","mem"]
-  revision = "63644898a8da0bc22138abf860edaf5277b6102e"
-  version = "v1.1.0"
+  revision = "787d034dfe70e44075ccc060d346146ef53270ad"
+  version = "v1.1.1"
 
 [[projects]]
   name = "github.com/spf13/cast"
@@ -254,8 +252,8 @@
 [[projects]]
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
-  version = "v0.0.2"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
   branch = "master"
@@ -278,14 +276,14 @@
 [[projects]]
   name = "github.com/stretchr/testify"
   packages = ["assert","require"]
-  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
-  version = "v1.2.1"
+  revision = "f35b8ab0b5a2cef36673838d662e249dd9c94686"
+  version = "v1.2.2"
 
 [[projects]]
   branch = "master"
   name = "github.com/syndtr/goleveldb"
   packages = ["leveldb","leveldb/cache","leveldb/comparer","leveldb/errors","leveldb/filter","leveldb/iterator","leveldb/journal","leveldb/memdb","leveldb/opt","leveldb/storage","leveldb/table","leveldb/util"]
-  revision = "211f780988068502fe874c44dae530528ebd840f"
+  revision = "c4c61651e9e37fa117f53c5a906d3b63090d8445"
 
 [[projects]]
   branch = "master"
@@ -296,32 +294,32 @@
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = ["blake2s","nacl/secretbox","pbkdf2","poly1305","salsa20/salsa","scrypt","sha3"]
-  revision = "1875d0a70c90e57f11972aefd42276df65e895b9"
+  packages = ["blake2s","internal/subtle","nacl/secretbox","pbkdf2","poly1305","salsa20/salsa","scrypt","sha3"]
+  revision = "c126467f60eb25f8f27e5a981f32a87e3965053f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/net"
   packages = ["html","html/atom","html/charset","websocket"]
-  revision = "2fb46b16b8dda405028c50f7c7f0f9dd1fa6bfb1"
+  revision = "3673e40ba22529d22c3fd7c93e97b0ce50fa7bdd"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sync"
   packages = ["syncmap"]
-  revision = "fd80eb99c8f653c847d294a001bdf2a3a6f768f5"
+  revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = ["unix"]
-  revision = "c488ab1dd8481ef762f96a79a9577c27825be697"
+  packages = ["cpu","unix"]
+  revision = "bd9dbc187b6e1dacfdd2722a87e83093c2d7bd6e"
 
 [[projects]]
-  branch = "master"
   name = "golang.org/x/text"
   packages = ["encoding","encoding/charmap","encoding/htmlindex","encoding/internal","encoding/internal/identifier","encoding/japanese","encoding/korean","encoding/simplifiedchinese","encoding/traditionalchinese","encoding/unicode","internal/gen","internal/tag","internal/triegen","internal/ucd","internal/utf8internal","language","runes","transform","unicode/cldr","unicode/norm"]
-  revision = "e19ae1496984b1c655b8044a65c0300a3c878dd3"
+  revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
+  version = "v0.3.0"
 
 [[projects]]
   name = "gopkg.in/fatih/set.v0"
@@ -344,6 +342,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "29990c2d339964afb3857185623892bd772b5fb68dbd03afc1884fa9ccf9ec7c"
+  inputs-digest = "b3a4ef8c80f5d4b68c6eabce3a0435894c035290fd7954b243f64e349c3a0e38"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,3 +72,16 @@
 [[constraint]]
   name = "github.com/multiformats/go-multihash"
   branch = "master"
+
+[[constraint]]
+  name = "github.com/ethereum/go-ethereum"
+  revision = "1e67410e88d2685bc54611a7c9f75c327b553ccc"
+
+[[constraint]]
+  name = "github.com/ipfs/go-ipld-cbor"
+  branch = "refmt"
+
+[[constraint]]
+  name = "github.com/quorumcontrol/chaintree"
+  revision = "a5b36259df6cd5b1f7867c58d0bd1b04ed128cc8"
+


### PR DESCRIPTION
This constrains a few versions of the dependencies (cbor node branch, go-ethereum version, and chaintree version). It then runs `dep ensure --update` to get the latest of a few deps.

Tests pass.