### PR TITLE
Add MINT_COIN transaction

### DIFF
--- a/consensus/signedtree.go
+++ b/consensus/signedtree.go
@@ -12,6 +12,7 @@ import (
 
 const (
 	TransactionTypeEstablishCoin = "ESTABLISH_COIN"
+	TransactionTypeMintCoin      = "MINT_COIN"
 	TransactionTypeSetData       = "SET_DATA"
 	TransactionTypeSetOwnership  = "SET_OWNERSHIP"
 	TransactionTypeStake         = "STAKE"
@@ -19,6 +20,7 @@ const (
 
 var DefaultTransactors = map[string]chaintree.TransactorFunc{
 	TransactionTypeEstablishCoin: EstablishCoinTransaction,
+	TransactionTypeMintCoin:      MintCoinTransaction,
 	TransactionTypeSetData:       SetDataTransaction,
 	TransactionTypeSetOwnership:  SetOwnershipTransaction,
 	TransactionTypeStake:         StakeTransaction,


### PR DESCRIPTION
Depends on https://github.com/QuorumControl/qc3/pull/19

This adds the `MINT_COIN` transaction which can be executed one or more times after `ESTABLISH_COIN`. Minting has few rules attached to it:
- Coin must have already been established in `ESTABLISH_COIN`
- Total mint amount across all transactions can never exceed the monetary policy maximum specified in `ESTABLISH_COIN`
- Must mint an amount greater than 0 

I *think* the last one makes sense especially from an immutably perspective , but I could also imagine that specifying a negative number would be akin to removing currency from circulation (of course only up to the amount that hasn't been sent). I think restricting to > 0 is probably the safer of the two options though, so I just went with that to start.