### PR TITLE
Update deployment for 3 server testnet

### DIFF
--- a/docker-compose-testnetwork.yml
+++ b/docker-compose-testnetwork.yml
@@ -27,78 +27,8 @@ services:
     environment:
       NODE_BLS_KEY_HEX: $NODE_2_BLS_KEY_HEX
       NODE_ECDSA_KEY_HEX: $NODE_2_ECDSA_KEY_HEX
-  node3:
-    image: qc3:latest
-    command: ["/usr/bin/qc3", "test-node", "-k", "/bootstrap-keys.json"]
-    volumes:
-      - node3:/var/lib/qc3
-      - ./bootstrap-keys.json:/bootstrap-keys.json
-    environment:
-      NODE_BLS_KEY_HEX: $NODE_3_BLS_KEY_HEX
-      NODE_ECDSA_KEY_HEX: $NODE_3_ECDSA_KEY_HEX
-  node4:
-    image: qc3:latest
-    command: ["/usr/bin/qc3", "test-node", "-k", "/bootstrap-keys.json"]
-    volumes:
-      - node4:/var/lib/qc3
-      - ./bootstrap-keys.json:/bootstrap-keys.json
-    environment:
-      NODE_BLS_KEY_HEX: $NODE_4_BLS_KEY_HEX
-      NODE_ECDSA_KEY_HEX: $NODE_4_ECDSA_KEY_HEX
-  node5:
-    image: qc3:latest
-    command: ["/usr/bin/qc3", "test-node", "-k", "/bootstrap-keys.json"]
-    volumes:
-      - node5:/var/lib/qc3
-      - ./bootstrap-keys.json:/bootstrap-keys.json
-    environment:
-      NODE_BLS_KEY_HEX: $NODE_5_BLS_KEY_HEX
-      NODE_ECDSA_KEY_HEX: $NODE_5_ECDSA_KEY_HEX
-  node6:
-    image: qc3:latest
-    command: ["/usr/bin/qc3", "test-node", "-k", "/bootstrap-keys.json"]
-    volumes:
-      - node6:/var/lib/qc3
-      - ./bootstrap-keys.json:/bootstrap-keys.json
-    environment:
-      NODE_BLS_KEY_HEX: $NODE_6_BLS_KEY_HEX
-      NODE_ECDSA_KEY_HEX: $NODE_6_ECDSA_KEY_HEX
-  node7:
-    image: qc3:latest
-    command: ["/usr/bin/qc3", "test-node", "-k", "/bootstrap-keys.json"]
-    volumes:
-      - node7:/var/lib/qc3
-      - ./bootstrap-keys.json:/bootstrap-keys.json
-    environment:
-      NODE_BLS_KEY_HEX: $NODE_7_BLS_KEY_HEX
-      NODE_ECDSA_KEY_HEX: $NODE_7_ECDSA_KEY_HEX
-  node8:
-    image: qc3:latest
-    command: ["/usr/bin/qc3", "test-node", "-k", "/bootstrap-keys.json"]
-    volumes:
-      - node8:/var/lib/qc3
-      - ./bootstrap-keys.json:/bootstrap-keys.json
-    environment:
-      NODE_BLS_KEY_HEX: $NODE_8_BLS_KEY_HEX
-      NODE_ECDSA_KEY_HEX: $NODE_8_ECDSA_KEY_HEX
-  node9:
-    image: qc3:latest
-    command: ["/usr/bin/qc3", "test-node", "-k", "/bootstrap-keys.json"]
-    volumes:
-      - node9:/var/lib/qc3
-      - ./bootstrap-keys.json:/bootstrap-keys.json
-    environment:
-      NODE_BLS_KEY_HEX: $NODE_9_BLS_KEY_HEX
-      NODE_ECDSA_KEY_HEX: $NODE_9_ECDSA_KEY_HEX
 
 volumes:
   node0:
   node1:
   node2:
-  node3:
-  node4:
-  node5:
-  node6:
-  node7:
-  node8:
-  node9:

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -2,21 +2,26 @@
 
 TARGET_DIR="/go/src/github.com/quorumcontrol/qc3/"
 IMAGE_AND_TAG="qc3:latest"
-HOST="debian@51.15.114.122"
+HOSTS=("debian@51.15.114.122" "debian@51.15.78.52" "debian@51.15.45.207")
 
 pushd `dirname $0`/../
 trap popd EXIT
 
-ssh $HOST "mkdir -p $TARGET_DIR"
-
 docker build --tag $IMAGE_AND_TAG .
-
 docker save -o .storage/dockerimage.tar qc3:latest
 
-scp .storage/dockerimage.tar $HOST:$TARGET_DIR/
+remoteCmds() {
+  local HOST=$1
+  ssh $HOST "mkdir -p $TARGET_DIR"
+  scp .storage/dockerimage.tar $HOST:$TARGET_DIR/
+  ssh $HOST "cd $TARGET_DIR && docker load -i dockerimage.tar && rm -f dockerimage.tar"
+  scp docker-compose-testnetwork.yml $HOST:$TARGET_DIR/docker-compose.yml
+}
+
+for h in "${HOSTS[@]}"; do
+  remoteCmds "$h" &
+done
+
+wait
 
 rm -f .storage/dockerimage.tar
-
-ssh $HOST "cd $TARGET_DIR && docker load -i dockerimage.tar && rm -f dockerimage.tar"
-
-scp docker-compose-testnetwork.yml $HOST:$TARGET_DIR/docker-compose.yml

--- a/scripts/server-bootstrap.sh
+++ b/scripts/server-bootstrap.sh
@@ -23,7 +23,10 @@ add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian $(
 
 apt-get update
 
-apt-get install -y docker-ce docker-compose
+apt-get install -y docker-ce
+
+curl -L https://github.com/docker/compose/releases/download/1.22.0/docker-compose-`uname -s`-`uname -m` -o /usr/bin/docker-compose
+chmod +x /usr/bin/docker-compose
 
 # debian user is created by default with limited permissions and already has same ssh keys as root assigned
 usermod -a -G docker debian


### PR DESCRIPTION
Update the helper scripts here for the 3 server setup. In order to avoid any special snowflakes, this reduced the overall signer nodes from 10 to 9 (3 on each server). If the 10 is important, I can change it back.