### PR TITLE
Proposal: Add PPROF_ENABLED flag for turning on pprof http server

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -123,6 +123,22 @@
   version = "0.2"
 
 [[projects]]
+  digest = "1:dbbeb8ddb0be949954c8157ee8439c2adfd8dc1c9510eb44a6e58cb68c3dce28"
+  name = "github.com/gorilla/context"
+  packages = ["."]
+  pruneopts = ""
+  revision = "08b5f424b9271eedf6f9f0ce86cb9396ed337a42"
+  version = "v1.1.1"
+
+[[projects]]
+  digest = "1:c2c8666b4836c81a1d247bdf21c6a6fc1ab586538ab56f74437c2e0df5c375e1"
+  name = "github.com/gorilla/mux"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e3702bed27f0d39777b0b37b664b6280e8ef8fbf"
+  version = "v1.6.2"
+
+[[projects]]
   branch = "master"
   digest = "1:1e529576e7eaa5e9d6fc46dc241527d54c01a5244fbcce9c151f6d52dcc576e3"
   name = "github.com/gxed/hashland"
@@ -594,6 +610,7 @@
     "github.com/ethereum/go-ethereum/p2p/discover",
     "github.com/ethereum/go-ethereum/whisper/whisperv6",
     "github.com/google/uuid",
+    "github.com/gorilla/mux",
     "github.com/ipfs/go-cid",
     "github.com/ipfs/go-ipld-cbor",
     "github.com/mitchellh/go-homedir",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -85,3 +85,6 @@
   name = "github.com/quorumcontrol/chaintree"
   version = "v0.0.3"
 
+[[constraint]]
+  name = "github.com/gorilla/mux"
+  version = "1.6.2"

--- a/main.go
+++ b/main.go
@@ -1,9 +1,33 @@
 package main
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/pprof"
+	"os"
+
+	"github.com/gorilla/mux"
 	"github.com/quorumcontrol/qc3/cmd"
 )
 
 func main() {
+	if os.Getenv("PPROF_ENABLED") == "true" {
+		go func() {
+			debugR := mux.NewRouter()
+			debugR.HandleFunc("/debug/pprof/", pprof.Index)
+			debugR.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+			debugR.HandleFunc("/debug/pprof/profile", pprof.Profile)
+			debugR.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+			debugR.Handle("/debug/pprof/heap", pprof.Handler("heap"))
+			debugR.Handle("/debug/pprof/goroutine", pprof.Handler("goroutine"))
+			debugR.Handle("/debug/pprof/block", pprof.Handler("block"))
+			debugR.Handle("/debug/pprof/threadcreate", pprof.Handler("threadcreate"))
+			err := http.ListenAndServe(":8080", debugR)
+			if err != nil {
+				fmt.Println(err.Error())
+			}
+		}()
+	}
+
 	cmd.Execute()
 }


### PR DESCRIPTION
In order to do profiling on the testnet, I've been using the following code which spins up a webserver serving up the pprof dumps. I figured I'ld throw this up behind the PPROF_ENABLED env variable and see if we thought it makes sense to just go ahead and add to the codebase. Thoughts?