### PR TITLE
gsub _qc chaintree prefixes/dids with _tupelo

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -90,7 +90,7 @@ type StandardHeaders struct {
 }
 
 func AddrToDid(addr string) string {
-	return fmt.Sprintf("did:qc:%s", addr)
+	return fmt.Sprintf("did:tupelo:%s", addr)
 }
 
 func DidToAddr(did string) string {

--- a/consensus/transactions.go
+++ b/consensus/transactions.go
@@ -12,9 +12,9 @@ import (
 )
 
 const (
-	TreePathForAuthentications = "_qc/authentications"
-	TreePathForCoins           = "_qc/coins"
-	TreePathForStake           = "_qc/stake"
+	TreePathForAuthentications = "_tupelo/authentications"
+	TreePathForCoins           = "_tupelo/coins"
+	TreePathForStake           = "_tupelo/stake"
 )
 
 func init() {
@@ -54,7 +54,7 @@ func complexType(obj interface{}) bool {
 	}
 }
 
-// SetDataTransaction just sets a path in a tree to arbitrary data. It makes sure no data is being changed in the _qc path.
+// SetDataTransaction just sets a path in a tree to arbitrary data. It makes sure no data is being changed in the _tupelo path.
 func SetDataTransaction(tree *dag.Dag, transaction *chaintree.Transaction) (newTree *dag.Dag, valid bool, codedErr chaintree.CodedError) {
 	payload := &SetDataPayload{}
 	err := typecaster.ToType(transaction.Payload, payload)
@@ -62,8 +62,8 @@ func SetDataTransaction(tree *dag.Dag, transaction *chaintree.Transaction) (newT
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error casting payload: %v", err)}
 	}
 
-	if payload.Path == "_qc" || strings.HasPrefix(payload.Path, "_qc/") {
-		return nil, false, &ErrorCode{Code: 999, Memo: "the path prefix _qc is reserved"}
+	if payload.Path == "_tupelo" || strings.HasPrefix(payload.Path, "_tupelo/") {
+		return nil, false, &ErrorCode{Code: 999, Memo: "the path prefix _tupelo is reserved"}
 	}
 
 	if complexType(payload.Value) {
@@ -82,7 +82,7 @@ type SetOwnershipPayload struct {
 	Authentication []*PublicKey
 }
 
-// SetOwnershipTransaction changes the ownership of a tree by adding a public key array to /_qc/authentications
+// SetOwnershipTransaction changes the ownership of a tree by adding a public key array to /_tupelo/authentications
 func SetOwnershipTransaction(tree *dag.Dag, transaction *chaintree.Transaction) (newTree *dag.Dag, valid bool, codedErr chaintree.CodedError) {
 	payload := &SetOwnershipPayload{}
 	err := typecaster.ToType(transaction.Payload, payload)

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -41,19 +41,19 @@ func TestEstablishCoinTransactionWithMaximum(t *testing.T) {
 	_, err = testTree.ProcessBlock(blockWithHeaders)
 	assert.Nil(t, err)
 
-	maximum, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "monetaryPolicy", "maximum"})
+	maximum, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "monetaryPolicy", "maximum"})
 	assert.Nil(t, err)
 	assert.Equal(t, maximum, uint64(42))
 
-	mints, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "mints"})
+	mints, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "mints"})
 	assert.Nil(t, err)
 	assert.Nil(t, mints)
 
-	sends, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "sends"})
+	sends, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "sends"})
 	assert.Nil(t, err)
 	assert.Nil(t, sends)
 
-	receives, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "receives"})
+	receives, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "receives"})
 	assert.Nil(t, err)
 	assert.Nil(t, receives)
 }
@@ -86,19 +86,19 @@ func TestEstablishCoinTransactionWithoutMonetaryPolicy(t *testing.T) {
 	_, err = testTree.ProcessBlock(blockWithHeaders)
 	assert.Nil(t, err)
 
-	maximum, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "monetaryPolicy", "maximum"})
+	maximum, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "monetaryPolicy", "maximum"})
 	assert.Nil(t, err)
 	assert.Empty(t, maximum)
 
-	mints, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "mints"})
+	mints, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "mints"})
 	assert.Nil(t, err)
 	assert.Nil(t, mints)
 
-	sends, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "sends"})
+	sends, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "sends"})
 	assert.Nil(t, err)
 	assert.Nil(t, sends)
 
-	receives, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "receives"})
+	receives, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "receives"})
 	assert.Nil(t, err)
 	assert.Nil(t, receives)
 }

--- a/signer/processblock_test.go
+++ b/signer/processblock_test.go
@@ -209,7 +209,7 @@ func TestprocessAddBlock(t *testing.T) {
 				{
 					Type: "SET_DATA",
 					Payload: map[string]interface{}{
-						"path":  "_qc/authentications/publicKey",
+						"path":  "_tupelo/authentications/publicKey",
 						"value": "test",
 					},
 				},
@@ -316,7 +316,7 @@ func TestSigner_CoinTransactions(t *testing.T) {
 
 		assert.Equal(t, resp.Tip, testTree.Dag.Tip)
 
-		mintAmount, _, err := testTree.Dag.Resolve([]string{"tree", "_qc", "coins", "testcoin", "mints", fmt.Sprint(testIndex), "amount"})
+		mintAmount, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "mints", fmt.Sprint(testIndex), "amount"})
 		assert.Nil(t, err)
 		assert.Equal(t, mintAmount, testAmount)
 	}


### PR DESCRIPTION
Just a quick change to help bring the alpha interface in closer proximity to our next iteration. Tests pass and tried the full lifecycle in the shell without errors.