### PR TITLE
Make generate-node-keys more robust

### DIFF
--- a/cmd/generateNodeKeys.go
+++ b/cmd/generateNodeKeys.go
@@ -1,13 +1,22 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"path/filepath"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/quorumcontrol/qc3/bls"
 	"github.com/quorumcontrol/qc3/consensus"
 	"github.com/spf13/cobra"
+)
+
+var (
+	generateNodeKeysCount  int
+	generateNodeKeysOutput string
+	generateNodeKeysPath   string
 )
 
 func generateKeySet(numberOfKeys int) (privateKeys []*PrivateKeySet, publicKeys []*PublicKeySet, err error) {
@@ -41,24 +50,53 @@ var generateNodeKeysCmd = &cobra.Command{
 	Short: "Generate a new set of node keys",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		privateKeys, publicKeys, err := generateKeySet(1)
+		privateKeys, publicKeys, err := generateKeySet(generateNodeKeysCount)
 
 		if err != nil {
 			panic(err)
 		}
 
-		fmt.Printf(
-			"bls: '%v'\nbls public: '%v'\necdsa: '%v'\necdsa public: '%v'\n",
-			privateKeys[0].BlsHexPrivateKey,
-			publicKeys[0].BlsHexPublicKey,
-			privateKeys[0].EcdsaHexPrivateKey,
-			publicKeys[0].EcdsaHexPublicKey,
-		)
+		switch generateNodeKeysOutput {
+		case "text":
+			for i := 1; i <= len(privateKeys); i++ {
+				fmt.Printf("================ Key %v ================\n", i)
+				fmt.Printf(
+					"bls: '%v'\nbls public: '%v'\necdsa: '%v'\necdsa public: '%v'\n",
+					privateKeys[0].BlsHexPrivateKey,
+					publicKeys[0].BlsHexPublicKey,
+					privateKeys[0].EcdsaHexPrivateKey,
+					publicKeys[0].EcdsaHexPublicKey,
+				)
+			}
+		case "json-file":
+			publicKeyJson, err := json.Marshal(publicKeys)
+			if err != nil {
+				panic(fmt.Sprintf("error writing json %v", err))
+			}
+			err = ioutil.WriteFile(filepath.Join(generateNodeKeysPath, "public-keys.json"), publicKeyJson, 0644)
+			if err != nil {
+				panic(fmt.Sprintf("error writing file %v", err))
+			}
+
+			privateKeyJson, err := json.Marshal(privateKeys)
+			if err != nil {
+				panic(fmt.Sprintf("error writing json %v", err))
+			}
+			err = ioutil.WriteFile(filepath.Join(generateNodeKeysPath, "private-keys.json"), privateKeyJson, 0644)
+			if err != nil {
+				panic(fmt.Sprintf("error writing file %v", err))
+			}
+		default:
+			panic(fmt.Sprintf("output=%v type is not supported", generateNodeKeysOutput))
+		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(generateNodeKeysCmd)
+	generateNodeKeysCmd.Flags().IntVarP(&generateNodeKeysCount, "count", "c", 1, "how many keys to generate")
+	generateNodeKeysCmd.Flags().StringVarP(&generateNodeKeysOutput, "output", "o", "text", "format for keys output (default text): text, json-file")
+	generateNodeKeysCmd.Flags().StringVarP(&generateNodeKeysPath, "path", "p", ".", "directory to store files if using json")
 
 	// Here you will define your flags and configuration settings.
 


### PR DESCRIPTION
Mainly this aims to port over https://github.com/QuorumControl/tupelo-benchmarking/blob/master/key-generator by adding support for `count` and `output` params