### PR TITLE
Skip doGossip if commit phase & 100% signers

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -665,6 +665,11 @@ func (g *Gossiper) handleTentativeCommitMessage(ctx context.Context, msg *Gossip
 		g.clearPendingMessages(csID)
 	}
 
+	// Skip gossiping if this is commit phase and we already have 100% sigs
+	if savedTrans.Phase == phaseCommit && len(savedTrans.TentativeCommitSignatures) >= len(roundInfo.Signers) {
+		return nil
+	}
+
 	g.doGossip(ctx, newMessage)
 
 	return nil


### PR DESCRIPTION
Added this yesterday during benchmarking to cut down on the message spam. I think this could be improved by looking at signers that haven't signed yet, and explicitly gossip to them. For now though, this shows a huge improvement in message bandwidth.