### PR TITLE
remove unnecessary bootstrap-private-keys command option

### DIFF
--- a/cmd/rpcserver.go
+++ b/cmd/rpcserver.go
@@ -11,11 +11,10 @@ import (
 )
 
 var (
-	bootstrapPrivateKeysFile string
-	tls                      bool
-	certFile                 string
-	keyFile                  string
-	localNetworkNodeCount    int
+	tls                   bool
+	certFile              string
+	keyFile               string
+	localNetworkNodeCount int
 )
 
 func loadPrivateKeyFile(path string) ([]*PrivateKeySet, error) {
@@ -55,23 +54,20 @@ var rpcServerCmd = &cobra.Command{
 	Use:   "rpc-server",
 	Short: "Launches a Tupelo RPC Server",
 	Run: func(cmd *cobra.Command, args []string) {
-		var privateKeys []*PrivateKeySet
-
 		if localNetworkNodeCount > 0 {
 			var err error
 			var publicKeys []*PublicKeySet
+			var privateKeys []*PrivateKeySet
+
 			privateKeys, publicKeys, err = generateKeySet(localNetworkNodeCount)
 			if err != nil {
 				panic("Can't generate node keys")
 			}
 			bootstrapPublicKeys = publicKeys
-		} else {
-			privateKeys, _ = loadPrivateKeyFile(bootstrapPrivateKeysFile)
-		}
-
-		signers := make([]*signer.GossipedSigner, len(privateKeys))
-		for i, keys := range privateKeys {
-			signers[i] = setupGossipNode(keys.EcdsaHexPrivateKey, keys.BlsHexPrivateKey)
+			signers := make([]*signer.GossipedSigner, len(privateKeys))
+			for i, keys := range privateKeys {
+				signers[i] = setupGossipNode(keys.EcdsaHexPrivateKey, keys.BlsHexPrivateKey)
+			}
 		}
 
 		notaryGroup := setupNotaryGroup(storage.NewMemStorage())
@@ -87,7 +83,6 @@ var rpcServerCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(rpcServerCmd)
 	rpcServerCmd.Flags().StringVarP(&bootstrapPublicKeysFile, "bootstrap-keys", "k", "", "which public keys to bootstrap the notary groups with")
-	rpcServerCmd.Flags().StringVarP(&bootstrapPrivateKeysFile, "bootstrap-private-keys", "s", "", "which private keys to bootstrap the notary groups with")
 	rpcServerCmd.Flags().IntVarP(&localNetworkNodeCount, "local-network", "l", 0, "Run local network with randomly generated keys, specifying number of nodes as argument. Mutually exlusive with bootstrap-*")
 	rpcServerCmd.Flags().BoolVarP(&tls, "tls", "t", false, "Encrypt connections with TLS/SSL")
 	rpcServerCmd.Flags().StringVarP(&certFile, "tls-cert", "C", "", "TLS certificate file")


### PR DESCRIPTION
This option was added just before we switched to generating random keys automatically. Auto-generated key feature made this option obsolete. 