### PR TITLE
Fix bug in gossip termination

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -665,8 +665,7 @@ func (g *Gossiper) handleTentativeCommitMessage(ctx context.Context, msg *Gossip
 		g.clearPendingMessages(csID)
 	}
 
-	// Skip gossiping if this is commit phase and we already have 100% sigs
-	if savedTrans.Phase == phaseCommit && len(savedTrans.TentativeCommitSignatures) >= len(roundInfo.Signers) {
+	if savedTrans.Phase == phaseCommit && len(msg.PhaseSignatures) == len(savedTrans.TentativeCommitSignatures) && len(savedTrans.TentativeCommitSignatures) >= len(roundInfo.Signers) {
 		return nil
 	}
 


### PR DESCRIPTION
I believe this fixes the bug we discussed on the call. The issue was that checking `len(newSigs)` wasn't being triggered when adding your own sig as a signer: https://github.com/QuorumControl/qc3/blob/7e791e5a9bff2ef3239ad8800d8b89beae9aeb70/gossip/gossip.go#L564-L567.

So now, this only terminates gossip when the length of signatures received is the same as it has stored and that those are greater than or equal to the number of signers for the round. This accounts for the signer seeing a new signature and when it adds its own signature