### PR TITLE
Use LRU cache for RoundInfo on notarygroup

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -201,6 +201,17 @@
   revision = "d9f6b97f8db22dd1e090fd0bbbe98f09cc7dd0a8"
 
 [[projects]]
+  digest = "1:3313a63031ae281e5f6fd7b0bbca733dfa04d2429df86519e3b4d4c016ccb836"
+  name = "github.com/hashicorp/golang-lru"
+  packages = [
+    ".",
+    "simplelru",
+  ]
+  pruneopts = ""
+  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
+  version = "v0.5.0"
+
+[[projects]]
   branch = "master"
   digest = "1:9b7c5846d70f425d7fe279595e32a20994c6075e87be03b5c367ed07280877c5"
   name = "github.com/hashicorp/hcl"
@@ -732,6 +743,7 @@
     "github.com/golang/protobuf/proto",
     "github.com/google/uuid",
     "github.com/gorilla/mux",
+    "github.com/hashicorp/golang-lru",
     "github.com/ipfs/go-block-format",
     "github.com/ipfs/go-cid",
     "github.com/ipfs/go-ipld-cbor",

--- a/consensus/notarygroup.go
+++ b/consensus/notarygroup.go
@@ -9,13 +9,13 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/log"
+	"github.com/hashicorp/golang-lru"
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipld-cbor"
 	"github.com/quorumcontrol/chaintree/chaintree"
 	"github.com/quorumcontrol/chaintree/nodestore"
 	"github.com/quorumcontrol/chaintree/typecaster"
 	"github.com/quorumcontrol/qc3/bls"
-
-	cid "github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipld-cbor"
 )
 
 func init() {
@@ -27,6 +27,7 @@ func init() {
 
 const (
 	defaultRoundLength = 30 // round length in seconds
+	roundCacheSize     = 20
 )
 
 // NotaryGroup is a wrapper around a Chain Tree specifically used
@@ -35,6 +36,7 @@ type NotaryGroup struct {
 	signedTree  *SignedChainTree
 	ID          string
 	RoundLength int // round length in seconds
+	roundCache  *lru.Cache
 }
 
 // RoundInfo is a struct that holds information about the round.
@@ -55,6 +57,10 @@ func NewNotaryGroup(id string, nodeStore nodestore.NodeStore) *NotaryGroup {
 	if err != nil {
 		panic("error creating new tree")
 	}
+	roundCache, err := lru.New(roundCacheSize)
+	if err != nil {
+		panic("error creating lru round cache")
+	}
 	return &NotaryGroup{
 		signedTree: &SignedChainTree{
 			ChainTree:  tree,
@@ -62,6 +68,7 @@ func NewNotaryGroup(id string, nodeStore nodestore.NodeStore) *NotaryGroup {
 		},
 		RoundLength: defaultRoundLength,
 		ID:          id,
+		roundCache:  roundCache,
 	}
 }
 
@@ -77,6 +84,10 @@ func (ng *NotaryGroup) CreateGenesisState(startRound int64, signers ...*RemoteNo
 
 // MostRecentRound returns the roundinfo that is most recent to the requested round.
 func (ng *NotaryGroup) MostRecentRoundInfo(round int64) (roundInfo *RoundInfo, err error) {
+	if cachedRoundInfo, ok := ng.roundCache.Get(round); ok {
+		return cachedRoundInfo.(*RoundInfo), nil
+	}
+
 	allRoundsUntyped, _, err := ng.signedTree.ChainTree.Dag.Resolve([]string{"tree", "rounds"})
 
 	if err != nil {
@@ -96,6 +107,11 @@ func (ng *NotaryGroup) MostRecentRoundInfo(round int64) (roundInfo *RoundInfo, e
 				return nil, err
 			}
 			if roundInfo != nil {
+				// Only cache current or past rounds
+				if round <= ng.RoundAt(time.Now()) {
+					ng.roundCache.ContainsOrAdd(r, roundInfo)
+				}
+
 				return
 			}
 		}


### PR DESCRIPTION
one of the low hanging fruit improvements in both the original benchmarking on the current codebase as well as in the gossip2 findings is to prevent 2 db reads on every `MostRecentRoundInfo` call. 