### PR TITLE
Remove GOPATH from built binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /go/src/github.com/quorumcontrol/qc3
 
 COPY . .
 
-RUN go install -v -a -ldflags '-extldflags "-static"'
+RUN go install -v -a -ldflags '-extldflags "-static"' -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH
 
 FROM debian:stretch-slim
 RUN mkdir -p /var/lib/qc3

--- a/scripts/release
+++ b/scripts/release
@@ -15,7 +15,7 @@ fi
 if ! [ "$(uname)" == "Darwin" ]; then
   echo "detected non mac os, skipping mac build"
 else
-  go build -o release/qc3-${version}-darwin-amd64 .
+  go build -o release/qc3-${version}-darwin-amd64 -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH .
 fi
 
 if ! [ -x "$(command -v docker)" ]; then


### PR DESCRIPTION
per @zonotope 's suggestion, this removes the users path from the built binary during a stacktrace, ex:

```
panic: Exit

goroutine 1 [running]:
main.main()
	src/github.com/quorumcontrol/qc3/main.go:32 +0x83
```