### PR TITLE
update BLS multisig to use new interface on kyber PR

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -84,7 +84,7 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:97437121c6e6df638b20aeb82cc743577676146adf3d2f55a5260556bb650f01"
+  digest = "1:0fb880a9bf3959a41f0d9e66c87699b7bb1eb08aca29326d2acd85c702bdf6e7"
   name = "github.com/dedis/kyber"
   packages = [
     ".",
@@ -97,7 +97,7 @@
     "xof/blake2xb",
   ]
   pruneopts = ""
-  revision = "2618429f2dcb08ad862f9f11e56adab2de58c228"
+  revision = "189774c4cc923eb3772a72eecbb50cec5eaf2610"
   source = "https://github.com/QuorumControl/kyber.git"
 
 [[projects]]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,4 +56,4 @@
 [[constraint]]
   name = "github.com/dedis/kyber"
   source = "https://github.com/QuorumControl/kyber.git"
-  revision = "2618429f2dcb08ad862f9f11e56adab2de58c228"
+  revision = "189774c4cc923eb3772a72eecbb50cec5eaf2610"

--- a/bls/bls.go
+++ b/bls/bls.go
@@ -23,7 +23,6 @@ type VerKey struct {
 	public kyber.Point
 }
 
-//TODO: encode the VerKey into these bytes
 func BytesToSignKey(keyBytes []byte) *SignKey {
 	scalar := suite.G2().Scalar()
 	err := scalar.UnmarshalBinary(keyBytes)
@@ -129,7 +128,8 @@ func VerifyMultiSig(sig, msg []byte, verKeys [][]byte) (bool, error) {
 		}
 		points[i] = p
 	}
-	err := dedisbls.VerifyMultiSignature(suite, points, msg, sig)
+	aggregatedPublic := dedisbls.AggregatePublicKeys(suite, points...)
+	err := dedisbls.Verify(suite, aggregatedPublic, msg, sig)
 	if err != nil {
 		return false, nil
 	}


### PR DESCRIPTION
Don't look at this on thanksgiving :)

This fixes the dep bug using a bad revision (and uses the new interface from the new revision).

Apologies on the force-push without thinking about repercussions... I was trying to do the "cleanup a PR for an external repo" and didn't think about how it would affect us.

