### PR TITLE
check for possible errors when starting wallet session in rpc server

### DIFF
--- a/wallet/walletrpc/server.go
+++ b/wallet/walletrpc/server.go
@@ -46,7 +46,11 @@ func (s *server) GenerateKey(ctx context.Context, req *GenerateKeyRequest) (*Gen
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	key, err := session.GenerateKey()
@@ -66,7 +70,11 @@ func (s *server) ListKeys(ctx context.Context, req *ListKeysRequest) (*ListKeysR
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	keys, err := session.ListKeys()
@@ -85,7 +93,11 @@ func (s *server) CreateChainTree(ctx context.Context, req *GenerateChainRequest)
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	chain, err := session.CreateChain(req.KeyAddr)
@@ -109,7 +121,11 @@ func (s *server) ExportChainTree(ctx context.Context, req *ExportChainRequest) (
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	serializedChain, err := session.ExportChain(req.ChainId)
@@ -128,7 +144,11 @@ func (s *server) ImportChainTree(ctx context.Context, req *ImportChainRequest) (
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	chain, err := session.ImportChain(req.KeyAddr, req.ChainTree)
@@ -152,7 +172,11 @@ func (s *server) ListChainIds(ctx context.Context, req *ListChainIdsRequest) (*L
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	ids, err := session.GetChainIds()
@@ -171,7 +195,11 @@ func (s *server) GetTip(ctx context.Context, req *GetTipRequest) (*GetTipRespons
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	tipCid, err := session.GetTip(req.ChainId)
@@ -190,7 +218,11 @@ func (s *server) SetOwner(ctx context.Context, req *SetOwnerRequest) (*SetOwnerR
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	newTip, err := session.SetOwner(req.ChainId, req.KeyAddr, req.NewOwnerKeys)
@@ -209,7 +241,11 @@ func (s *server) SetData(ctx context.Context, req *SetDataRequest) (*SetDataResp
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	tipCid, err := session.SetData(req.ChainId, req.KeyAddr, req.Path, req.Value)
@@ -228,7 +264,11 @@ func (s *server) Resolve(ctx context.Context, req *ResolveRequest) (*ResolveResp
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	pathSegments := strings.Split(req.Path, "/")
@@ -256,7 +296,11 @@ func (s *server) EstablishCoin(ctx context.Context, req *EstablishCoinRequest) (
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	tipCid, err := session.EstablishCoin(req.ChainId, req.KeyAddr, req.CoinName, req.Maximum)
@@ -275,7 +319,11 @@ func (s *server) MintCoin(ctx context.Context, req *MintCoinRequest) (*MintCoinR
 		return nil, err
 	}
 
-	session.Start(req.Creds.PassPhrase)
+	err = session.Start(req.Creds.PassPhrase)
+	if err != nil {
+		return nil, fmt.Errorf("error starting session: %v", err)
+	}
+
 	defer session.Stop()
 
 	tipCid, err := session.MintCoin(req.ChainId, req.KeyAddr, req.CoinName, req.Amount)


### PR DESCRIPTION
This is a minor improvement to provide clearer error messages when a client tries to start a wallet session without creating the wallet first. 