### PR TITLE
do not stop the client between requests

### DIFF
--- a/wallet/walletrpc/session.go
+++ b/wallet/walletrpc/session.go
@@ -143,7 +143,6 @@ func (rpcs *RPCSession) Start(passPhrase string) error {
 func (rpcs *RPCSession) Stop() {
 	if !rpcs.IsStopped() {
 		rpcs.wallet.Close()
-		rpcs.client.Stop()
 		rpcs.isStarted = false
 	}
 }


### PR DESCRIPTION
Ben noticed an error testing javascript using the rpc-server. This removes stopping the client between requests, which was causing swarm disconnect and dial backoff errors during repeat-requests.