### PR TITLE
add the GOMAXPROCS now that it's removed from this repo

### DIFF
--- a/gossip2/gossip.go
+++ b/gossip2/gossip.go
@@ -8,6 +8,8 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"os"
+	"runtime"
 	"sync"
 	"time"
 
@@ -20,6 +22,15 @@ import (
 	"github.com/quorumcontrol/tupelo/consensus"
 	"github.com/quorumcontrol/tupelo/p2p"
 )
+
+func init() {
+	// SEE: https://github.com/quorumcontrol/storage
+	// Using badger suggests a minimum of 128 GOMAXPROCS, but also
+	// allow the user to customize
+	if os.Getenv("GOMAXPROCS") == "" {
+		runtime.GOMAXPROCS(128)
+	}
+}
 
 var log = logging.Logger("gossip")
 


### PR DESCRIPTION
we removed badger from this repo, so the gomaxprocs went with it... this adds it back to the gossip2.go

I went back and forth on adding it to main.go or here. I ended up adding it here because I wanted the setting to show up in tests and not just in testing the binary.