### PR TITLE
Handle send coin in signers

### DIFF
--- a/consensus/signedtree.go
+++ b/consensus/signedtree.go
@@ -4,18 +4,17 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
-	"github.com/quorumcontrol/storage"
-
-	"github.com/quorumcontrol/chaintree/nodestore"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ipfs/go-cid"
 	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/storage"
 )
 
 const (
 	TransactionTypeEstablishCoin = "ESTABLISH_COIN"
 	TransactionTypeMintCoin      = "MINT_COIN"
+	TransactionTypeSendCoin      = "SEND_COIN"
 	TransactionTypeSetData       = "SET_DATA"
 	TransactionTypeSetOwnership  = "SET_OWNERSHIP"
 	TransactionTypeStake         = "STAKE"
@@ -24,6 +23,7 @@ const (
 var DefaultTransactors = map[string]chaintree.TransactorFunc{
 	TransactionTypeEstablishCoin: EstablishCoinTransaction,
 	TransactionTypeMintCoin:      MintCoinTransaction,
+	TransactionTypeSendCoin:      SendCoinTransaction,
 	TransactionTypeSetData:       SetDataTransaction,
 	TransactionTypeSetOwnership:  SetOwnershipTransaction,
 	TransactionTypeStake:         StakeTransaction,

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -102,3 +102,93 @@ func TestEstablishCoinTransactionWithoutMonetaryPolicy(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, receives)
 }
+
+func TestSendCoin(t *testing.T) {
+	key, err := crypto.GenerateKey()
+	assert.Nil(t, err)
+
+	store := nodestore.NewStorageBasedStore(storage.NewMemStorage())
+	treeDID := AddrToDid(crypto.PubkeyToAddress(key.PublicKey).String())
+	emptyTree := NewEmptyTree(treeDID, store)
+
+	maximumAmount := uint64(50)
+	blockWithHeaders := &chaintree.BlockWithHeaders{
+		Block: chaintree.Block{
+			PreviousTip: "",
+			Transactions: []*chaintree.Transaction{
+				{
+					Type: "ESTABLISH_COIN",
+					Payload: map[string]interface{}{
+						"name": "testcoin",
+					},
+				},
+				{
+					Type: "MINT_COIN",
+					Payload: map[string]interface{}{
+						"name":   "testcoin",
+						"amount": maximumAmount,
+					},
+				},
+			},
+		},
+	}
+
+	testTree, err := chaintree.NewChainTree(emptyTree, nil, DefaultTransactors)
+	assert.Nil(t, err)
+
+	_, err = testTree.ProcessBlock(blockWithHeaders)
+	assert.Nil(t, err)
+
+	targetKey, err := crypto.GenerateKey()
+	targetTreeDID := AddrToDid(crypto.PubkeyToAddress(targetKey.PublicKey).String())
+
+	sendBlockWithHeaders := &chaintree.BlockWithHeaders{
+		Block: chaintree.Block{
+			PreviousTip: testTree.Dag.Tip.String(),
+			Transactions: []*chaintree.Transaction{
+				{
+					Type: "SEND_COIN",
+					Payload: map[string]interface{}{
+						"id":          "1234",
+						"name":        "testcoin",
+						"amount":      30,
+						"destination": targetTreeDID,
+					},
+				},
+			},
+		},
+	}
+
+	_, err = testTree.ProcessBlock(sendBlockWithHeaders)
+	assert.Nil(t, err)
+
+	sends, _, err := testTree.Dag.Resolve([]string{"tree", "_tupelo", "coins", "testcoin", "sends", "0"})
+	assert.Nil(t, err)
+	assert.NotNil(t, sends)
+
+	sendsMap := sends.(map[string]interface{})
+	assert.Equal(t, sendsMap["id"], "1234")
+	assert.Equal(t, sendsMap["amount"], uint64(30))
+	lastSendAmount := sendsMap["amount"].(uint64)
+	assert.Equal(t, sendsMap["destination"], targetTreeDID)
+
+	overSpendBlockWithHeaders := &chaintree.BlockWithHeaders{
+		Block: chaintree.Block{
+			PreviousTip: testTree.Dag.Tip.String(),
+			Transactions: []*chaintree.Transaction{
+				{
+					Type: "SEND_COIN",
+					Payload: map[string]interface{}{
+						"id":          "1234",
+						"name":        "testcoin",
+						"amount":      (maximumAmount - lastSendAmount) + 1,
+						"destination": targetTreeDID,
+					},
+				},
+			},
+		},
+	}
+
+	_, err = testTree.ProcessBlock(overSpendBlockWithHeaders)
+	assert.NotNil(t, err)
+}


### PR DESCRIPTION
Not completed, but good checkpoint here - adds in the logic on the signer side for send coin. There still needs to be the actual drafting of the "cashiers check" after signing is complete. To note, I expect in the next iteration to pull most of the logic inside `SendCoinTransaction` into a wallet/bookkeeping/ledger class that can contain methods like `Balance()` and `Send()` 