### PR TITLE
Skip signature calculation if conflict set is done

### DIFF
--- a/gossip2/gossip.go
+++ b/gossip2/gossip.go
@@ -247,6 +247,9 @@ func (gn *GossipNode) handleNewObjCh() {
 			if !ok {
 				panic("this should never happen")
 			}
+			if conflictSetStat.IsDone {
+				continue
+			}
 			if resp.Error != nil {
 				// at minimum delete it out of storage
 				panic(fmt.Sprintf("TODO: handle this gracefully: %v", resp.Error))


### PR DESCRIPTION
This is a rework of https://github.com/quorumcontrol/tupelo/pull/89 --- 2 changes:

1) it checks when processing a signature or transaction - transaction is necessary because signatures can come in before the transaction, and then the transaction must trigger the verification.
2) it puts the final ProvideMessage (either deadlocked or done) onto the front of the pending messages so its processed first. This means other messages inside the newObjCh may still be processed first, but typically the done message will take precedence. 