### PR TITLE
generic gossipclient interface

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -78,12 +78,6 @@ type PublicKey struct {
 	PublicKey []byte `refmt:"publicKey,omitempty" json:"publicKey,omitempty" cbor:"publicKey,omitempty"`
 }
 
-type Signature struct {
-	Signers   []bool `refmt:"signers,omitempty" json:"signers,omitempty" cbor:"signers,omitempty"`
-	Signature []byte `refmt:"signature,omitempty" json:"signature,omitempty" cbor:"signature,omitempty"`
-	Type      string `refmt:"type,omitempty" json:"type,omitempty" cbor:"type,omitempty"`
-}
-
 type StandardHeaders struct {
 	Signatures SignatureMap `refmt:"signatures,omitempty" json:"signatures,omitempty" cbor:"signatures,omitempty"`
 }

--- a/consensus/types.go
+++ b/consensus/types.go
@@ -11,10 +11,8 @@ import (
 func init() {
 	cbornode.RegisterCborType(AddBlockRequest{})
 	cbornode.RegisterCborType(AddBlockResponse{})
-	cbornode.RegisterCborType(FeedbackRequest{})
 	cbornode.RegisterCborType(TipRequest{})
 	cbornode.RegisterCborType(TipResponse{})
-	cbornode.RegisterCborType(TipSignature{})
 	cbornode.RegisterCborType(GetDiffNodesRequest{})
 	cbornode.RegisterCborType(GetDiffNodesResponse{})
 }
@@ -40,6 +38,7 @@ type AddBlockRequest struct {
 	ChainId  string
 	Nodes    [][]byte
 	Tip      *cid.Cid
+	NewTip   *cid.Cid
 	NewBlock *chaintree.BlockWithHeaders
 }
 
@@ -59,10 +58,10 @@ type GetDiffNodesResponse struct {
 	Nodes [][]byte
 }
 
-type FeedbackRequest struct {
-	ChainId   string
-	Tip       *cid.Cid
-	Signature Signature
+type Signature struct {
+	Signers   []bool `refmt:"signers,omitempty" json:"signers,omitempty" cbor:"signers,omitempty"`
+	Signature []byte `refmt:"signature,omitempty" json:"signature,omitempty" cbor:"signature,omitempty"`
+	Type      string `refmt:"type,omitempty" json:"type,omitempty" cbor:"type,omitempty"`
 }
 
 type TipRequest struct {
@@ -70,12 +69,10 @@ type TipRequest struct {
 }
 
 type TipResponse struct {
-	ChainId   string
-	Tip       *cid.Cid
-	Signature Signature
-}
-
-type TipSignature struct {
-	Tip       *cid.Cid
-	Signature Signature
+	ChainId     string
+	Tip         *cid.Cid
+	PreviousTip *cid.Cid
+	Cycle       uint64
+	Epoch       uint64
+	Signature   Signature
 }

--- a/gossip2/gossip_integration_test.go
+++ b/gossip2/gossip_integration_test.go
@@ -405,7 +405,7 @@ func TestDeadlockTransactionGossip(t *testing.T) {
 		ObjectID:    []byte(treeDID),
 	}
 
-	require.True(t, string(transaction2.ID()) < string(transaction1.ID()))
+	require.True(t, string(transaction1.ID()) < string(transaction2.ID()))
 
 	_, err = gossipNodes[0].InitiateTransaction(transaction2)
 	require.Nil(t, err)
@@ -445,10 +445,10 @@ func TestDeadlockTransactionGossip(t *testing.T) {
 
 	time.Sleep(500 * time.Millisecond)
 
-	currState, err := gossipNodes[0].getCurrentState(transaction1.ObjectID)
+	currState, err := gossipNodes[0].getCurrentState(transaction2.ObjectID)
 	require.Nil(t, err)
 
-	assert.Equal(t, transaction2.NewTip, currState.Tip)
+	assert.Equal(t, transaction1.NewTip, currState.Tip)
 }
 
 func TestSubscription(t *testing.T) {

--- a/gossipclient/interface.go
+++ b/gossipclient/interface.go
@@ -1,0 +1,14 @@
+package gossipclient
+
+import (
+	"crypto/ecdsa"
+	"time"
+
+	"github.com/quorumcontrol/tupelo/consensus"
+)
+
+type GossipClient interface {
+	Subscribe(signerDstKey *ecdsa.PublicKey, did string, timeout time.Duration) (respChan chan *consensus.TipResponse, err error)
+	AddBlock(signerDstKey *ecdsa.PublicKey, request *consensus.AddBlockRequest) error
+	GetTip(signerDstKey *ecdsa.PublicKey, request *consensus.TipRequest) (*consensus.TipResponse, error)
+}


### PR DESCRIPTION
I was looking at all the various places where we'd have to swap gossip2/gossip3 and wanted to make this easier in the future... so I'm proposing an interface below for a gossipclient and the various gossipers would translate their internal types back into the consensus package types.

Adding NewTip to the addblockrequest because both gossipers now require sending in that new tip.

Also removes two unneeded types