### PR TITLE
unsubscribe handler

### DIFF
--- a/gossip3/actors/subscriptionhandler.go
+++ b/gossip3/actors/subscriptionhandler.go
@@ -1,23 +1,51 @@
 package actors
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/AsynkronIT/protoactor-go/plugin"
 	"github.com/quorumcontrol/tupelo/gossip3/messages"
 	"github.com/quorumcontrol/tupelo/gossip3/middleware"
 )
 
-type subscriptionHolder map[string][]*actor.PID
+type actorPIDHolder map[string]*actor.PID
 
+var subscriptionTimeout = 2 * time.Minute
+
+type objectSubscriptionManager struct {
+	middleware.LogAwareHolder
+
+	subscriptions actorPIDHolder
+}
+
+func newObjectSubscriptionManagerProps() *actor.Props {
+	return actor.FromProducer(func() actor.Actor {
+		return &objectSubscriptionManager{
+			subscriptions: make(actorPIDHolder),
+		}
+	}).WithMiddleware(
+		middleware.LoggingMiddleware,
+		plugin.Use(&middleware.LogPlugin{}),
+	)
+}
+
+// The SubscriptionHandler is responsible for informing actors on tip changes. It is implemented
+// using workers for each ObjectID because it's easier to implement a timeout that way.
+// Any subscription that is not notified within subscriptionTimeout duration will automatically
+// deregister itself.
 type SubscriptionHandler struct {
 	middleware.LogAwareHolder
-	subscriptions subscriptionHolder
+
+	subscriptionManagers actorPIDHolder
 }
 
 func NewSubscriptionHandlerProps() *actor.Props {
 	return actor.FromProducer(func() actor.Actor {
 		return &SubscriptionHandler{
-			subscriptions: make(subscriptionHolder),
+			subscriptionManagers: make(actorPIDHolder),
 		}
 	}).WithMiddleware(
 		middleware.LoggingMiddleware,
@@ -27,21 +55,70 @@ func NewSubscriptionHandlerProps() *actor.Props {
 
 func (sh *SubscriptionHandler) Receive(context actor.Context) {
 	switch msg := context.Message().(type) {
+	case *actor.Terminated:
+		split := strings.Split(msg.Who.GetId(), "/")
+		objectID := split[len(split)-1]
+		if _, ok := sh.subscriptionManagers[objectID]; ok {
+			delete(sh.subscriptionManagers, objectID)
+		}
 	case *messages.TipSubscription:
-		sh.subscribe(context, msg)
+		manager, ok := sh.subscriptionManagers[string(msg.ObjectID)]
+		if msg.Unsubscribe && !ok {
+			return
+		}
+		if !ok {
+			manager = sh.newManager(context, msg.ObjectID)
+		}
+
+		context.Forward(manager)
 	case *messages.CurrentStateWrapper:
-		sh.notifySubscribers(context, msg)
+		manager, ok := sh.subscriptionManagers[string(msg.CurrentState.Signature.ObjectID)]
+		if ok {
+			context.Forward(manager)
+		}
 	}
 }
 
-func (sh *SubscriptionHandler) subscribe(context actor.Context, msg *messages.TipSubscription) {
-	subs := sh.subscriptions[string(msg.ObjectID)]
-	sh.subscriptions[string(msg.ObjectID)] = append(subs, context.Sender())
+func (sh *SubscriptionHandler) newManager(context actor.Context, objectID []byte) *actor.PID {
+	m, err := context.SpawnNamed(newObjectSubscriptionManagerProps(), string(objectID))
+	if err != nil {
+		panic(fmt.Sprintf("error spawning: %v", err))
+	}
+	sh.subscriptionManagers[string(objectID)] = m
+	return m
 }
 
-func (sh *SubscriptionHandler) notifySubscribers(context actor.Context, msg *messages.CurrentStateWrapper) {
-	subs := sh.subscriptions[string(msg.CurrentState.Signature.ObjectID)]
-	for _, sub := range subs {
+func (osm *objectSubscriptionManager) Receive(context actor.Context) {
+	switch msg := context.Message().(type) {
+	case *actor.ReceiveTimeout:
+		context.SetReceiveTimeout(0)
+		context.Self().Stop()
+	case *messages.TipSubscription:
+		context.SetReceiveTimeout(subscriptionTimeout)
+		if msg.Unsubscribe {
+			osm.unsubscribe(context, msg)
+		} else {
+			osm.subscribe(context, msg)
+		}
+	case *messages.CurrentStateWrapper:
+		context.SetReceiveTimeout(subscriptionTimeout)
+		osm.notifySubscribers(context, msg)
+	}
+}
+
+func (osm *objectSubscriptionManager) subscribe(context actor.Context, msg *messages.TipSubscription) {
+	osm.subscriptions[context.Sender().String()] = context.Sender()
+}
+
+func (osm *objectSubscriptionManager) unsubscribe(context actor.Context, msg *messages.TipSubscription) {
+	delete(osm.subscriptions, context.Sender().String())
+	if len(osm.subscriptions) == 0 {
+		context.Self().Stop()
+	}
+}
+
+func (osm *objectSubscriptionManager) notifySubscribers(context actor.Context, msg *messages.CurrentStateWrapper) {
+	for _, sub := range osm.subscriptions {
 		context.Request(sub, msg.CurrentState)
 	}
 }


### PR DESCRIPTION
~This has #105 in it, so a bit of a bigger diff, only real changes in this one are subscriptionhandler.go and the test for it.~ [update: 105 was merged, so rebased]

This implements unsubscribe and changes how the subscription handler does things - using an actor per objectID being watched... this allows those actors to timeout individually when not being used and clean themselves up in a pretty straightforward way.