### PR TITLE
handle push syncer panics

### DIFF
--- a/gossip3/actors/pushsyncer.go
+++ b/gossip3/actors/pushsyncer.go
@@ -44,6 +44,8 @@ func NewPushSyncerProps(kind string, storageActor *actor.PID) *actor.Props {
 	).WithSupervisor(supervisor)
 }
 
+var syncerReceiveTimeout = 10 * time.Second
+
 func (syncer *PushSyncer) Receive(context actor.Context) {
 	// this makes sure the protocol continues along
 	// and will terminate when nothing is happening
@@ -55,19 +57,19 @@ func (syncer *PushSyncer) Receive(context actor.Context) {
 		syncer.Log.Infow("timeout")
 		context.Self().Poison()
 	case *messages.DoPush:
-		context.SetReceiveTimeout(2 * time.Second)
+		context.SetReceiveTimeout(syncerReceiveTimeout)
 		syncer.handleDoPush(context, msg)
 	case *messages.ProvideStrata:
-		context.SetReceiveTimeout(2 * time.Second)
+		context.SetReceiveTimeout(syncerReceiveTimeout)
 		syncer.handleProvideStrata(context, msg)
 	case *messages.RequestIBF:
-		context.SetReceiveTimeout(2 * time.Second)
+		context.SetReceiveTimeout(syncerReceiveTimeout)
 		syncer.handleRequestIBF(context, msg)
 	case *messages.ProvideBloomFilter:
-		context.SetReceiveTimeout(2 * time.Second)
+		context.SetReceiveTimeout(syncerReceiveTimeout)
 		syncer.handleProvideBloomFilter(context, msg)
 	case *messages.RequestKeys:
-		context.SetReceiveTimeout(2 * time.Second)
+		context.SetReceiveTimeout(syncerReceiveTimeout)
 		syncer.handleRequestKeys(context, msg)
 	case *messages.Debug:
 		syncer.Log.Debugf("message: %v", msg.Message)


### PR DESCRIPTION
when the push syncer paniced, the global supervisor would restart the actor... however that actor would just be sitting there not doing anything, yet still be holding open its slot. 

This is two pronged... one it starts the timeout at the very beginning of a push syncer and it also uses a new supervisor to *stop* the push syncer on a panic. The gossiper will startup a new one when it gets the terminated notice.