### PR TITLE
Flag based logging for gossip3

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	ipfslogging "github.com/ipsn/go-ipfs/gxlibs/github.com/ipfs/go-log"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/quorumcontrol/tupelo/gossip3"
 	"github.com/shibukawa/configdir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -52,6 +53,15 @@ var logLevels = map[string]log.Lvl{
 	"info":     log.LvlInfo,
 	"debug":    log.LvlDebug,
 	"trace":    log.LvlTrace,
+}
+
+var zapLogLevels = map[string]string{
+	"critical": "panic",
+	"error":    "error",
+	"warn":     "warn",
+	"info":     "info",
+	"debug":    "debug",
+	"trace":    "debug",
 }
 
 func getLogLevel(lvlName string) (log.Lvl, error) {
@@ -165,6 +175,7 @@ var rootCmd = &cobra.Command{
 			fmt.Println("unknown ipfs log level")
 		}
 
+		gossip3.SetLogLevel(zapLogLevels[logLvlName])
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if newKeysFile != "" {

--- a/gossip3/gossip.go
+++ b/gossip3/gossip.go
@@ -1,1 +1,7 @@
 package gossip3
+
+import "github.com/quorumcontrol/tupelo/gossip3/middleware"
+
+func SetLogLevel(level string) error {
+	return middleware.SetLogLevel(level)
+}

--- a/gossip3/middleware/logging.go
+++ b/gossip3/middleware/logging.go
@@ -6,8 +6,10 @@ import (
 )
 
 var Log *zap.SugaredLogger
+var globalLevel zap.AtomicLevel
 
 func init() {
+	globalLevel = zap.NewAtomicLevelAt(zap.WarnLevel)
 	Log = buildLogger()
 }
 
@@ -43,9 +45,13 @@ func LoggingMiddleware(next actor.ActorFunc) actor.ActorFunc {
 	return fn
 }
 
+func SetLogLevel(level string) error {
+	return globalLevel.UnmarshalText([]byte(level))
+}
+
 func buildLogger() *zap.SugaredLogger {
 	cfg := zap.NewDevelopmentConfig()
-	cfg.Level.SetLevel(zap.InfoLevel)
+	cfg.Level = globalLevel
 
 	logger, err := cfg.Build()
 	if err != nil {

--- a/gossip3/middleware/logging_test.go
+++ b/gossip3/middleware/logging_test.go
@@ -1,0 +1,18 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestSetLogLevel(t *testing.T) {
+	SetLogLevel("error")
+	assert.True(t, Log.Desugar().Core().Enabled(zapcore.ErrorLevel))
+	assert.False(t, Log.Desugar().Core().Enabled(zapcore.DebugLevel))
+
+	SetLogLevel("debug")
+	assert.True(t, Log.Desugar().Core().Enabled(zapcore.ErrorLevel))
+	assert.True(t, Log.Desugar().Core().Enabled(zapcore.DebugLevel))
+}


### PR DESCRIPTION
https://trello.com/c/Lsn43n1j

Controls gossip3s logging via the `-L` flag of the tupelo commands. @tobowers also mentioned using zap elsewhere, so going to investigate doing a more full swap to `zap` and if thats a worthwhile task I'll open up another PR.