### PR TITLE
add two benchmarks for validation and signature generation

### DIFF
--- a/testnotarygroup/testnotarygroup.go
+++ b/testnotarygroup/testnotarygroup.go
@@ -49,7 +49,7 @@ type TestSet struct {
 	SignKeysByAddress map[string]*bls.SignKey
 }
 
-func NewTestSet(t *testing.T, size int) *TestSet {
+func NewTestSet(t testing.TB, size int) *TestSet {
 	signKeys := blsKeys(size)
 	verKeys := make([]*bls.VerKey, len(signKeys))
 	pubKeys := make([]consensus.PublicKey, len(signKeys))


### PR DESCRIPTION
I just wanted to see what our theoretical maximum was using cbor,etc. 
FWIW:
```
BenchmarkSignatureGenerator-128     	    5000	    273914 ns/op	    3153 B/op	      56 allocs/op
BenchmarkValidator-128              	    2000	    680472 ns/op	  203189 B/op	    3334 allocs/op
```

0.27ms for sig generation = 3700 ops/sec
and
0.68ms for validator = 1470 ops/sec