### PR TITLE
Fix path decoding with leading /

### DIFF
--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -102,3 +102,45 @@ func TestEstablishCoinTransactionWithoutMonetaryPolicy(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Nil(t, receives)
 }
+
+func TestDecodePath(t *testing.T) {
+	dp1, err := decodePath("/some/data")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"some", "data"}, dp1)
+
+	dp2, err := decodePath("some/data")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"some", "data"}, dp2)
+
+	dp3, err := decodePath("//some/data")
+	assert.NotNil(t, err)
+	assert.Nil(t, dp3)
+
+	dp4, err := decodePath("/some//data")
+	assert.NotNil(t, err)
+	assert.Nil(t, dp4)
+
+	dp5, err := decodePath("/some/../data")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"some", "..", "data"}, dp5)
+
+	dp6, err := decodePath("")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{""}, dp6)
+
+	dp7, err := decodePath("/")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{""}, dp7)
+
+	dp8, err := decodePath("/_tupelo")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"_tupelo"}, dp8)
+
+	dp9, err := decodePath("_tupelo")
+	assert.Nil(t, err)
+	assert.Equal(t, []string{"_tupelo"}, dp9)
+
+	dp10, err := decodePath("//_tupelo")
+	assert.NotNil(t, err)
+	assert.Nil(t, dp10)
+}


### PR DESCRIPTION
Fixes [this bug](https://trello.com/c/NcRs5Nu5).

Please look over [the test cases](https://github.com/quorumcontrol/tupelo/blob/bug/broken-tree-paths/consensus/transactions_test.go#L106-L146) for the new `decodePath` func and make sure those are all indeed the desired behavior. Let me know if there are others I should add.

Paired with @brandonwestcott on this.