### PR TITLE
Add new Wallet with per chaintree configurable storage

### DIFF
--- a/wallet/file.go
+++ b/wallet/file.go
@@ -269,9 +269,6 @@ func (fw *FileWallet) ListKeys() ([]string, error) {
 	return addrs, nil
 }
 
-var chainPrefix = []byte("-c-")
-var keyPrefix = []byte("-k-")
-
 func chainIdWithPrefix(chainID []byte) []byte {
 	return append(chainPrefix, chainID...)
 }

--- a/wallet/wallet.go
+++ b/wallet/wallet.go
@@ -1,0 +1,306 @@
+package wallet
+
+import (
+	"crypto/ecdsa"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipld-cbor"
+	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/chaintree/dag"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/chaintree/safewrap"
+	"github.com/quorumcontrol/storage"
+	"github.com/quorumcontrol/tupelo/consensus"
+)
+
+// just make sure that implementation conforms to the interface
+var _ consensus.Wallet = (*Wallet)(nil)
+
+// Wallet stores keys and metadata about a chaintree (id, signatures, storage adapter / config)
+type Wallet struct {
+	storage storage.Storage
+}
+
+type StorageAdapterConfig struct {
+	Adapter   string
+	Arguments map[string]interface{}
+}
+
+type WalletConfig struct {
+	Storage storage.Storage
+}
+
+type ExistingChainError struct {
+	publicKey *ecdsa.PublicKey
+}
+
+func (e ExistingChainError) Error() string {
+	keyAddr := crypto.PubkeyToAddress(*e.publicKey).String()
+	return fmt.Sprintf("A chain tree for public key %v has already been created.", keyAddr)
+}
+
+func NewWallet(config *WalletConfig) *Wallet {
+	return &Wallet{storage: config.Storage}
+}
+
+func (w *Wallet) Close() {
+	w.storage.Close()
+}
+
+func (w *Wallet) GetTip(chainId string) ([]byte, error) {
+	tip, err := w.storage.Get(chainStorageKey([]byte(chainId)))
+	if err != nil {
+		return nil, fmt.Errorf("error getting tip for chain id %v: %v", chainId, err)
+	}
+
+	return tip, nil
+}
+
+func (w *Wallet) GetChain(chainId string) (*consensus.SignedChainTree, error) {
+	tip, err := w.GetTip(chainId)
+	if err != nil {
+		return nil, fmt.Errorf("error getting chain: %v", err)
+	}
+
+	signatures, err := w.storage.Get(signatureStorageKey([]byte(chainId)))
+	if err != nil {
+		return nil, fmt.Errorf("error getting signatures: %v", err)
+	}
+
+	sigs := make(consensus.SignatureMap)
+	if len(signatures) > 0 {
+		err = cbornode.DecodeInto(signatures, &sigs)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding signatures: %v", err)
+		}
+	}
+
+	tipCid, err := cid.Cast(tip)
+	if err != nil {
+		return nil, fmt.Errorf("error casting tip: %v", err)
+	}
+
+	storageAdapter, err := w.storageAdapterForChain(chainId)
+	defer storageAdapter.Close()
+	nodeStore := nodestore.NewStorageBasedStore(storageAdapter)
+	storedTree := dag.NewDag(tipCid, nodeStore)
+
+	nodes, err := storedTree.Nodes()
+	if err != nil {
+		return nil, fmt.Errorf("error fetching stored nodes: %v", err)
+	}
+
+	memoryStore := nodestore.NewStorageBasedStore(storage.NewMemStorage())
+	memoryTree := dag.NewDag(tipCid, memoryStore)
+	memoryTree.AddNodes(nodes...)
+
+	tree, err := chaintree.NewChainTree(memoryTree, nil, consensus.DefaultTransactors)
+	if err != nil {
+		return nil, fmt.Errorf("error creating tree: %v", err)
+	}
+
+	return &consensus.SignedChainTree{
+		ChainTree:  tree,
+		Signatures: sigs,
+	}, nil
+}
+
+func (w *Wallet) CreateChain(keyAddr string, storageConfig *StorageAdapterConfig) (*consensus.SignedChainTree, error) {
+	key, err := w.GetKey(keyAddr)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting key: %v", err)
+	}
+
+	if w.ChainExists(keyAddr) {
+		return nil, ExistingChainError{publicKey: &key.PublicKey}
+	}
+
+	chain, err := consensus.NewSignedChainTree(key.PublicKey, nodestore.NewStorageBasedStore(storage.NewMemStorage()))
+	if err != nil {
+		return nil, err
+	}
+
+	chainId, err := chain.Id()
+	if err != nil {
+		return nil, err
+	}
+
+	err = w.ConfigureChainStorage(chainId, storageConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	err = w.SaveChain(chain)
+	if err != nil {
+		return nil, err
+	}
+
+	return chain, err
+}
+
+func (w *Wallet) ConfigureChainStorage(chainId string, storageConfig *StorageAdapterConfig) error {
+	storageConfigBytes, err := json.Marshal(storageConfig)
+	if err != nil {
+		return fmt.Errorf("Could not marshal storage config into json: %v", err)
+	}
+
+	return w.storage.Set(datastoreConfigStorageKey([]byte(chainId)), storageConfigBytes)
+}
+
+func (w *Wallet) SaveChain(signedChain *consensus.SignedChainTree) error {
+	chainId, err := signedChain.Id()
+	if err != nil {
+		return fmt.Errorf("error getting signedChain id: %v", err)
+	}
+
+	storageAdapter, err := w.storageAdapterForChain(chainId)
+	if err != nil {
+		return fmt.Errorf("error fetching storage adapter: %v", err)
+	}
+	defer storageAdapter.Close()
+
+	nodes, err := signedChain.ChainTree.Dag.Nodes()
+	if err != nil {
+		return fmt.Errorf("error getting nodes: %v", err)
+	}
+	for _, node := range nodes {
+		storageAdapter.Set(node.Cid().Bytes(), node.RawData())
+	}
+
+	sw := &safewrap.SafeWrap{}
+	signatureNode := sw.WrapObject(signedChain.Signatures)
+	if sw.Err != nil {
+		return fmt.Errorf("error wrapping signatures: %v", sw.Err)
+	}
+
+	w.storage.Set(signatureStorageKey([]byte(chainId)), signatureNode.RawData())
+	w.storage.Set(chainStorageKey([]byte(chainId)), signedChain.ChainTree.Dag.Tip.Bytes())
+
+	return nil
+}
+
+func (w *Wallet) ChainExistsForKey(keyAddr string) bool {
+	key, err := w.GetKey(keyAddr)
+	if err != nil {
+		return false
+	}
+	chainId := consensus.EcdsaPubkeyToDid(key.PublicKey)
+	return w.ChainExists(chainId)
+}
+
+func (w *Wallet) ChainExists(chainId string) bool {
+	tip, _ := w.GetTip(chainId)
+	return tip != nil && len(tip) > 0
+}
+
+func (w *Wallet) GetChainIds() ([]string, error) {
+	chainIds, err := w.storage.GetKeysByPrefix(chainPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("error getting saved chain tree ids; %v", err)
+	}
+
+	stringIds := make([]string, len(chainIds))
+	for i, k := range chainIds {
+		stringIds[i] = string(k[len(chainPrefix):])
+	}
+
+	return stringIds, nil
+}
+
+func (w *Wallet) GetKey(addr string) (*ecdsa.PrivateKey, error) {
+	keyBytes, err := w.storage.Get(keyStorageKey(common.HexToAddress(addr).Bytes()))
+	if err != nil {
+		return nil, fmt.Errorf("error getting key: %v", err)
+	}
+	return crypto.ToECDSA(keyBytes)
+}
+
+func (w *Wallet) GenerateKey() (*ecdsa.PrivateKey, error) {
+	key, err := crypto.GenerateKey()
+
+	fmt.Println(len(key.D.Bytes()))
+
+	if err != nil {
+		return nil, fmt.Errorf("error generating key: %v", err)
+	}
+
+	err = w.storage.Set(keyStorageKey(crypto.PubkeyToAddress(key.PublicKey).Bytes()), crypto.FromECDSA(key))
+	if err != nil {
+		return nil, fmt.Errorf("error generating key: %v", err)
+	}
+
+	return key, nil
+}
+
+func (w *Wallet) ListKeys() ([]string, error) {
+	keys, err := w.storage.GetKeysByPrefix(keyPrefix)
+	if err != nil {
+		return nil, fmt.Errorf("error getting keys; %v", err)
+	}
+	addrs := make([]string, len(keys))
+	for i, k := range keys {
+		addrs[i] = common.BytesToAddress(k[len(keyPrefix):]).String()
+	}
+	return addrs, nil
+}
+
+func (w *Wallet) storageAdapterForChain(chainId string) (storage.Storage, error) {
+	configB, err := w.storage.Get(datastoreConfigStorageKey([]byte(chainId)))
+
+	if err != nil {
+		return nil, fmt.Errorf("Could not fetch storage adapter %v", err)
+	}
+
+	if len(configB) == 0 {
+		return nil, fmt.Errorf("No storage configured for chaintree %v", chainId)
+	}
+
+	var config StorageAdapterConfig
+
+	err = json.Unmarshal(configB, &config)
+	if err != nil {
+		return nil, fmt.Errorf("Could not parse storage adapter %v", err)
+	}
+
+	return w.storageAdapterFromConfig(&config)
+}
+
+func (w *Wallet) storageAdapterFromConfig(storageConfig *StorageAdapterConfig) (storage.Storage, error) {
+	switch storageConfig.Adapter {
+	case "badger":
+		path, ok := storageConfig.Arguments["path"]
+
+		if !ok {
+			return nil, fmt.Errorf("Badger requires path in StorageConfig")
+		}
+
+		return storage.NewBadgerStorage(path.(string))
+	default:
+		return nil, fmt.Errorf("Unknown storage adapter: %v", storageConfig.Adapter)
+	}
+}
+
+var chainPrefix = []byte("-c-")
+var keyPrefix = []byte("-k-")
+var signaturePrefix = []byte("-s-")
+var datastorePrefix = []byte("-d-")
+
+func chainStorageKey(chainID []byte) []byte {
+	return append(chainPrefix, chainID...)
+}
+
+func signatureStorageKey(chainID []byte) []byte {
+	return append(signaturePrefix, chainID...)
+}
+
+func datastoreConfigStorageKey(chainID []byte) []byte {
+	return append(datastorePrefix, chainID...)
+}
+
+func keyStorageKey(addr []byte) []byte {
+	return append(keyPrefix, addr...)
+}

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -1,0 +1,273 @@
+package wallet
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	cid "github.com/ipfs/go-cid"
+	"github.com/ipfs/go-ipld-cbor"
+	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/chaintree/safewrap"
+	"github.com/quorumcontrol/storage"
+	"github.com/quorumcontrol/tupelo/consensus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWallet_GetChain(t *testing.T) {
+	w := NewWallet(&WalletConfig{Storage: storage.NewMemStorage()})
+	defer w.Close()
+
+	os.RemoveAll("testtmp")
+	os.MkdirAll("testtmp", 0700)
+	defer os.RemoveAll("testtmp")
+
+	key, err := w.GenerateKey()
+	require.Nil(t, err)
+
+	keyAddr := crypto.PubkeyToAddress(key.PublicKey).String()
+
+	newChain, err := w.CreateChain(keyAddr, &StorageAdapterConfig{
+		Adapter: "badger",
+		Arguments: map[string]interface{}{
+			"path": "testtmp/adapter",
+		},
+	})
+	require.Nil(t, err)
+
+	err = w.SaveChain(newChain)
+	require.Nil(t, err)
+
+	savedChain, err := w.GetChain(newChain.MustId())
+	assert.Nil(t, err)
+
+	assert.Equal(t, newChain.Tip(), savedChain.Tip())
+
+	origNodes, err := newChain.ChainTree.Dag.Nodes()
+	require.Nil(t, err)
+
+	savedNodes, err := savedChain.ChainTree.Dag.Nodes()
+	require.Nil(t, err)
+	assert.Equal(t, len(origNodes), len(savedNodes))
+
+	origCids := make([]string, len(origNodes))
+	newCids := make([]string, len(savedNodes))
+
+	for i, node := range origNodes {
+		origCids[i] = node.Cid().String()
+	}
+
+	for i, node := range savedNodes {
+		newCids[i] = node.Cid().String()
+	}
+	sort.Strings(origCids)
+	sort.Strings(newCids)
+
+	assert.Equal(t, origCids, newCids)
+}
+
+func TestWallet_SaveChain(t *testing.T) {
+	w := NewWallet(&WalletConfig{Storage: storage.NewMemStorage()})
+	defer w.Close()
+
+	os.RemoveAll("testtmp")
+	os.MkdirAll("testtmp", 0700)
+	defer os.RemoveAll("testtmp")
+
+	key, err := w.GenerateKey()
+	require.Nil(t, err)
+
+	keyAddr := crypto.PubkeyToAddress(key.PublicKey).String()
+
+	signedTree, err := w.CreateChain(keyAddr, &StorageAdapterConfig{
+		Adapter: "badger",
+		Arguments: map[string]interface{}{
+			"path": "testtmp/adapter",
+		},
+	})
+	require.Nil(t, err)
+
+	err = w.SaveChain(signedTree)
+	require.Nil(t, err)
+
+	savedTree, err := w.GetChain(signedTree.MustId())
+	assert.Nil(t, err)
+	signedNodes, err := signedTree.ChainTree.Dag.Nodes()
+	require.Nil(t, err)
+
+	savedNodes, err := savedTree.ChainTree.Dag.Nodes()
+	require.Nil(t, err)
+	assert.Equal(t, len(signedNodes), len(savedNodes))
+
+	hsh := crypto.Keccak256([]byte("hi"))
+
+	ecdsaSig, _ := crypto.Sign(hsh, key)
+
+	sig := &consensus.Signature{
+		Type:      consensus.KeyTypeSecp256k1,
+		Signature: ecdsaSig,
+	}
+
+	signedTree.Signatures = consensus.SignatureMap{
+		"id": *sig,
+	}
+
+	err = w.SaveChain(signedTree)
+	require.Nil(t, err)
+
+	savedTree, err = w.GetChain(signedTree.MustId())
+	assert.Nil(t, err)
+
+	savedNodes, err = savedTree.ChainTree.Dag.Nodes()
+	require.Nil(t, err)
+
+	assert.Equal(t, len(signedNodes), len(savedNodes))
+
+	unsignedBlock := &chaintree.BlockWithHeaders{
+		Block: chaintree.Block{
+			PreviousTip: "",
+			Transactions: []*chaintree.Transaction{
+				{
+					Type: consensus.TransactionTypeSetData,
+					Payload: &consensus.SetDataPayload{
+						Path:  "something",
+						Value: "hi",
+					},
+				},
+			},
+		},
+	}
+
+	blockWithHeaders, err := consensus.SignBlock(unsignedBlock, key)
+	require.Nil(t, err)
+
+	newTree := signedTree.ChainTree.Dag.WithNewTip(signedTree.ChainTree.Dag.Tip)
+
+	unmarshaledRoot, err := newTree.Get(newTree.Tip)
+	require.Nil(t, err)
+	require.NotNil(t, unmarshaledRoot)
+
+	root := &chaintree.RootNode{}
+
+	err = cbornode.DecodeInto(unmarshaledRoot.RawData(), root)
+	require.Nil(t, err)
+
+	require.NotNil(t, root.Tree)
+
+	newTree.Tip = *root.Tree
+
+	newTree.Set(strings.Split("something", "/"), "hi")
+	signedTree.ChainTree.Dag.SetAsLink([]string{chaintree.TreeLabel}, newTree)
+
+	chainNode, err := signedTree.ChainTree.Dag.Get(*root.Chain)
+	require.Nil(t, err)
+	chainData, err := nodestore.CborNodeToObj(chainNode)
+	chainMap := chainData.(map[string]interface{})
+	require.Nil(t, err)
+
+	sw := &safewrap.SafeWrap{}
+
+	wrappedBlock := sw.WrapObject(blockWithHeaders)
+	require.Nil(t, sw.Err)
+
+	lastEntry := &chaintree.ChainEntry{
+		PreviousTip:       "",
+		BlocksWithHeaders: []cid.Cid{wrappedBlock.Cid()},
+	}
+	entryNode := sw.WrapObject(lastEntry)
+	chainMap["end"] = entryNode.Cid()
+	newChainNode := sw.WrapObject(chainMap)
+
+	signedTree.ChainTree.Dag.AddNodes(entryNode)
+	signedTree.ChainTree.Dag.AddNodes(wrappedBlock)
+	signedTree.ChainTree.Dag.Update([]string{chaintree.ChainLabel}, newChainNode)
+
+	t.Log(signedTree.ChainTree.Dag.Dump())
+
+	err = w.SaveChain(signedTree)
+	require.Nil(t, err)
+
+	savedTree, err = w.GetChain(signedTree.MustId())
+	require.Nil(t, err)
+	savedNodes, err = savedTree.ChainTree.Dag.Nodes()
+	require.Nil(t, err)
+
+	assert.Equal(t, len(signedNodes), len(savedNodes))
+
+}
+
+func TestWallet_GetChainIds(t *testing.T) {
+	w := NewWallet(&WalletConfig{Storage: storage.NewMemStorage()})
+	defer w.Close()
+
+	os.RemoveAll("testtmp")
+	os.MkdirAll("testtmp", 0700)
+	defer os.RemoveAll("testtmp")
+
+	createdChains := make([]string, 3, 3)
+
+	for i := 0; i < 3; i++ {
+		key, err := w.GenerateKey()
+		require.Nil(t, err)
+
+		keyAddr := crypto.PubkeyToAddress(key.PublicKey).String()
+		signedTree, err := w.CreateChain(keyAddr, &StorageAdapterConfig{
+			Adapter: "badger",
+			Arguments: map[string]interface{}{
+				"path": fmt.Sprintf("testtmp/db-%d", i),
+			},
+		})
+		createdChains[i] = signedTree.MustId()
+		require.Nil(t, err)
+	}
+
+	ids, err := w.GetChainIds()
+	assert.Nil(t, err)
+
+	assert.ElementsMatch(t, createdChains, ids)
+}
+
+func TestWallet_GetKey(t *testing.T) {
+	w := NewWallet(&WalletConfig{Storage: storage.NewMemStorage()})
+	defer w.Close()
+
+	key, err := w.GenerateKey()
+	assert.Nil(t, err)
+
+	retKey, err := w.GetKey(crypto.PubkeyToAddress(key.PublicKey).String())
+	assert.Equal(t, retKey, key)
+}
+
+func TestWallet_ChainExists(t *testing.T) {
+	w := NewWallet(&WalletConfig{Storage: storage.NewMemStorage()})
+	defer w.Close()
+
+	os.RemoveAll("testtmp")
+	os.MkdirAll("testtmp", 0700)
+	defer os.RemoveAll("testtmp")
+
+	key, err := w.GenerateKey()
+	require.Nil(t, err)
+
+	keyAddr := crypto.PubkeyToAddress(key.PublicKey).String()
+	chainId := consensus.EcdsaPubkeyToDid(key.PublicKey)
+
+	assert.False(t, w.ChainExistsForKey(keyAddr))
+	assert.False(t, w.ChainExists(chainId))
+
+	signedTree, err := w.CreateChain(keyAddr, &StorageAdapterConfig{
+		Adapter: "badger",
+		Arguments: map[string]interface{}{
+			"path": "testtmp/adapter",
+		},
+	})
+	require.Nil(t, err)
+
+	assert.True(t, w.ChainExistsForKey(keyAddr))
+	assert.True(t, w.ChainExists(signedTree.MustId()))
+}


### PR DESCRIPTION
This is the first in a line of what are intending to be smaller PRs on reworking storage.

First up, a generic Wallet interface that can support different storage backends per chaintree.  Largely this is the same interface as `FileWallet` with a few small differences:
- Chains must either be created with `CreateChain` or configured via `ConfigureChainStorage` (for imports) - this allows the wallet to store the storage adapter & arguments along with that chaintree.
- moved in `ChainExists`
- left out `Unlock` and the `Create` / `CreateIfNotExists` methods as those are opinionated to that specific type of storage
- the idea of `NodeStore()` also goes away given those are now per chaintree

Next PR will change FileWallet to be a small, opinionated shim to use this as its backend.