### PR TITLE
Make FileWallet opinionated shim to Wallet

### DIFF
--- a/consensus/signedtree.go
+++ b/consensus/signedtree.go
@@ -4,13 +4,11 @@ import (
 	"crypto/ecdsa"
 	"fmt"
 
-	"github.com/quorumcontrol/storage"
-
-	"github.com/quorumcontrol/chaintree/nodestore"
-
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ipfs/go-cid"
 	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/storage"
 )
 
 const (

--- a/wallet/file_test.go
+++ b/wallet/file_test.go
@@ -13,8 +13,8 @@ import (
 	"github.com/quorumcontrol/chaintree/chaintree"
 	"github.com/quorumcontrol/chaintree/nodestore"
 	"github.com/quorumcontrol/chaintree/safewrap"
-	"github.com/quorumcontrol/tupelo/consensus"
 	"github.com/quorumcontrol/storage"
+	"github.com/quorumcontrol/tupelo/consensus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -72,7 +72,7 @@ func TestFileWallet_GetChain(t *testing.T) {
 	fw.CreateIfNotExists("password")
 	defer fw.Close()
 
-	key, err := crypto.GenerateKey()
+	key, err := fw.GenerateKey()
 	require.Nil(t, err)
 
 	signedTree := newSavedChain(t, fw, key.PublicKey)
@@ -111,7 +111,7 @@ func TestFileWallet_SaveChain(t *testing.T) {
 	fw.CreateIfNotExists("password")
 	defer fw.Close()
 
-	key, err := crypto.GenerateKey()
+	key, err := fw.GenerateKey()
 	require.Nil(t, err)
 
 	signedTree := newSavedChain(t, fw, key.PublicKey)
@@ -235,7 +235,7 @@ func TestFileWallet_GetChainIds(t *testing.T) {
 	fw.CreateIfNotExists("password")
 	defer fw.Close()
 
-	key, err := crypto.GenerateKey()
+	key, err := fw.GenerateKey()
 	require.Nil(t, err)
 
 	chain := newSavedChain(t, fw, key.PublicKey)


### PR DESCRIPTION
This is just a temporary change to make the current FileWallet interface delegate to the new `Wallet` - I think eventually we'll switch out the external interfaces to use a config spec, but for now this reduces duplicate code to maintain.