### PR TITLE
Add sha256 to release package

### DIFF
--- a/scripts/release
+++ b/scripts/release
@@ -28,7 +28,7 @@ generateSha256() {
     container_id=$(docker run -d --entrypoint=tail alpine -f /dev/null)
     docker cp $zipdir/$filename $container_id:$filename
     sha256=$(docker exec $container_id sha256sum $filename)
-    echo $sha256 > $zipdir/$filename.sha256.checksum
+    echo $sha256 >> $releasedir/tupelo-${version}-checksums.txt
   fi
 }
 


### PR DESCRIPTION
https://trello.com/c/KeZpbuFo

Just quickly adds a `sha256sum`s to the the release zip for both binaries. I realize we'll want to publish these somewhere authoritatively & separately, but for now at least automatically generates them into the zip.

