### PR TITLE
Use DecodePath in other places splitting path strings

### DIFF
--- a/consensus/transactions.go
+++ b/consensus/transactions.go
@@ -54,7 +54,7 @@ func complexType(obj interface{}) bool {
 	}
 }
 
-func decodePath(path string) ([]string, error) {
+func DecodePath(path string) ([]string, error) {
 	trimmed := strings.TrimPrefix(path, "/")
 	split := strings.Split(trimmed, "/")
 	if len(split) > 1 { // []string{""} is the only valid path with an empty string
@@ -75,7 +75,7 @@ func SetDataTransaction(tree *dag.Dag, transaction *chaintree.Transaction) (newT
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error casting payload: %v", err)}
 	}
 
-	path, err := decodePath(payload.Path)
+	path, err := DecodePath(payload.Path)
 	if err != nil {
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error decoding path: %v", err)}
 	}
@@ -108,7 +108,7 @@ func SetOwnershipTransaction(tree *dag.Dag, transaction *chaintree.Transaction) 
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error casting payload: %v", err)}
 	}
 
-	path, err := decodePath(TreePathForAuthentications)
+	path, err := DecodePath(TreePathForAuthentications)
 	if err != nil {
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error decoding path: %v", err)}
 	}
@@ -146,7 +146,7 @@ func EstablishCoinTransaction(tree *dag.Dag, transaction *chaintree.Transaction)
 	}
 
 	coinName := payload.Name
-	path, err := decodePath(TreePathForCoins)
+	path, err := DecodePath(TreePathForCoins)
 	if err != nil {
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error decoding path: %v", err)}
 	}
@@ -194,7 +194,7 @@ func MintCoinTransaction(tree *dag.Dag, transaction *chaintree.Transaction) (new
 	}
 
 	coinName := payload.Name
-	path, err := decodePath(TreePathForCoins)
+	path, err := DecodePath(TreePathForCoins)
 	if err != nil {
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error decoding path: %v", err)}
 	}
@@ -288,7 +288,7 @@ func StakeTransaction(tree *dag.Dag, transaction *chaintree.Transaction) (newTre
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error casting payload: %v", err)}
 	}
 
-	path, err := decodePath(TreePathForStake)
+	path, err := DecodePath(TreePathForStake)
 	if err != nil {
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error decoding path: %v", err)}
 	}

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -163,43 +163,43 @@ func TestSetData(t *testing.T) {
 }
 
 func TestDecodePath(t *testing.T) {
-	dp1, err := decodePath("/some/data")
+	dp1, err := DecodePath("/some/data")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"some", "data"}, dp1)
 
-	dp2, err := decodePath("some/data")
+	dp2, err := DecodePath("some/data")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"some", "data"}, dp2)
 
-	dp3, err := decodePath("//some/data")
+	dp3, err := DecodePath("//some/data")
 	assert.NotNil(t, err)
 	assert.Nil(t, dp3)
 
-	dp4, err := decodePath("/some//data")
+	dp4, err := DecodePath("/some//data")
 	assert.NotNil(t, err)
 	assert.Nil(t, dp4)
 
-	dp5, err := decodePath("/some/../data")
+	dp5, err := DecodePath("/some/../data")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"some", "..", "data"}, dp5)
 
-	dp6, err := decodePath("")
+	dp6, err := DecodePath("")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{""}, dp6)
 
-	dp7, err := decodePath("/")
+	dp7, err := DecodePath("/")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{""}, dp7)
 
-	dp8, err := decodePath("/_tupelo")
+	dp8, err := DecodePath("/_tupelo")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"_tupelo"}, dp8)
 
-	dp9, err := decodePath("_tupelo")
+	dp9, err := DecodePath("_tupelo")
 	assert.Nil(t, err)
 	assert.Equal(t, []string{"_tupelo"}, dp9)
 
-	dp10, err := decodePath("//_tupelo")
+	dp10, err := DecodePath("//_tupelo")
 	assert.NotNil(t, err)
 	assert.Nil(t, dp10)
 }

--- a/wallet/walletrpc/server.go
+++ b/wallet/walletrpc/server.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ipfs/go-ipld-cbor"
+	cbornode "github.com/ipfs/go-ipld-cbor"
+	"github.com/quorumcontrol/tupelo/consensus"
 	"github.com/quorumcontrol/tupelo/gossip2client"
 	"github.com/quorumcontrol/tupelo/wallet"
 	"golang.org/x/net/context"
@@ -279,7 +280,10 @@ func (s *server) Resolve(ctx context.Context, req *ResolveRequest) (*ResolveResp
 
 	defer session.Stop()
 
-	pathSegments := strings.Split(req.Path, "/")
+	pathSegments, err := consensus.DecodePath(req.Path)
+	if err != nil {
+		return nil, fmt.Errorf("bad path: %v", err)
+	}
 
 	data, remainingSegments, err := session.Resolve(req.ChainId, pathSegments)
 	if err != nil {

--- a/wallet/walletshell/gossipshell.go
+++ b/wallet/walletshell/gossipshell.go
@@ -8,7 +8,8 @@ import (
 	"github.com/abiosoft/ishell"
 	"github.com/btcsuite/btcutil/base58"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ipfs/go-ipld-cbor"
+	cbornode "github.com/ipfs/go-ipld-cbor"
+	"github.com/quorumcontrol/tupelo/consensus"
 	"github.com/quorumcontrol/tupelo/gossip2client"
 	"github.com/quorumcontrol/tupelo/wallet/walletrpc"
 )
@@ -288,7 +289,12 @@ func RunGossip(name string, storagePath string, client *gossip2client.GossipClie
 				return
 			}
 
-			path := strings.Split(c.Args[1], "/")
+			path, err := consensus.DecodePath(c.Args[1])
+			if err != nil {
+				c.Printf("bad path: %v\n", err)
+				return
+			}
+
 			data, remaining, err := session.Resolve(c.Args[0], path)
 			if err != nil {
 				c.Printf("error resolving data: %v\n", err)


### PR DESCRIPTION
This completes the work started in https://github.com/quorumcontrol/tupelo/pull/127. Note that the discrepancy between path decoding algorithms meant that resolving paths that started with a leading `/` was broken on master and most likely in the 0.0.7 release as well. We should investigate why we didn't catch that in any testing (manual or automated).