### PR TITLE
Fix up CLI flag help strings a bit

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -210,9 +210,9 @@ func init() {
 	cobra.OnInitialize(initConfig)
 
 	rootCmd.PersistentFlags().StringVarP(&logLvlName, "log-level", "L", "error", "Log level")
-	rootCmd.PersistentFlags().IntVarP(&localNetworkNodeCount, "local-network", "l", 3, "Run local network with randomly generated keys, specifying number of nodes as argument (default: 3). Mutually exlusive with bootstrap-*")
-	rootCmd.PersistentFlags().BoolVarP(&remoteNetwork, "remote-network", "r", false, "connect to a remote network (mutually exclusive with -l / --local-network)")
-	rootCmd.PersistentFlags().StringVarP(&overrideKeysFile, "override-keys", "k", "", "path to notary group bootstrap keys file (implies -r / --remote-network)")
+	rootCmd.PersistentFlags().IntVarP(&localNetworkNodeCount, "local-network", "l", 3, "Run local network with randomly generated keys, specifying number of nodes as argument. Mutually exclusive with bootstrap-* and -r / --remote-network.")
+	rootCmd.PersistentFlags().BoolVarP(&remoteNetwork, "remote-network", "r", false, "Connect to a remote network. Mutually exclusive with -l / --local-network.")
+	rootCmd.PersistentFlags().StringVarP(&overrideKeysFile, "override-keys", "k", "", "Path to notary group bootstrap keys file. Implies -r / --remote-network.")
 	rootCmd.Flags().StringVarP(&newKeysFile, "import-boot-keys", "i", "", "Path of a notary group key file to import")
 }
 


### PR DESCRIPTION
Noticed some small improvements to make after my recent PR adding the -r flag.

I removed the "default: 3" from the -l flag because the flags library already adds that for you.