### PR TITLE
better benchmark for validator and reduce concurrency

### DIFF
--- a/gossip3/actors/validator.go
+++ b/gossip3/actors/validator.go
@@ -11,7 +11,7 @@ import (
 	"github.com/AsynkronIT/protoactor-go/router"
 	"github.com/ethereum/go-ethereum/crypto"
 	cid "github.com/ipfs/go-cid"
-	"github.com/ipfs/go-ipld-cbor"
+	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/quorumcontrol/chaintree/chaintree"
 	"github.com/quorumcontrol/chaintree/dag"
 	"github.com/quorumcontrol/chaintree/nodestore"
@@ -37,7 +37,7 @@ type TransactionValidator struct {
 	reader storage.Reader
 }
 
-const maxValidatorConcurrency = 100
+const maxValidatorConcurrency = 10
 
 func NewTransactionValidatorProps(currentStateStore storage.Storage) *actor.Props {
 	return router.NewRoundRobinPool(maxValidatorConcurrency).WithProducer(func() actor.Actor {

--- a/gossip3/actors/validator_test.go
+++ b/gossip3/actors/validator_test.go
@@ -54,12 +54,18 @@ func BenchmarkValidator(b *testing.B) {
 	require.Nil(b, err)
 	key := crypto.Keccak256(value)
 
+	futures := make([]*actor.Future, b.N, b.N)
+
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := validator.RequestFuture(&messages.Store{
+		f := validator.RequestFuture(&messages.Store{
 			Key:   key,
 			Value: value,
-		}, 1*time.Second).Result()
+		}, 5*time.Second)
+		futures[i] = f
+	}
+	for _, f := range futures {
+		_, err := f.Result()
 		require.Nil(b, err)
 	}
 }


### PR DESCRIPTION
I noticed a refmt upgrade which I thought might improve performance (it didn't). But... along the way noticed we were single-threading our benchmark. Note, this doesn't actually make our code faster, just gives us an accurate representation.

I also noticed that a concurrency of 100 was actually slightly reducing the benchmark (not a lot, but also meant it was unnecessary) - so reduced that down to 10.

I also profiled this and 25% of the time is spent in cgo verifying signatures.

Also remember, that this bench is the theoretical maximum throughput (the number of transactions can validate per second)

was: (single threaded) = ~ 1400tx/s
```
goos: darwin
goarch: amd64
pkg: github.com/quorumcontrol/tupelo/gossip3/actors
BenchmarkValidator-128     	    2000	    711963 ns/op	  180330 B/op	    2769 allocs/op
```

is: (testing concurrency) = ~4500tx/s
```
goos: darwin
goarch: amd64
pkg: github.com/quorumcontrol/tupelo/gossip3/actors
BenchmarkValidator-128     	    5000	    226819 ns/op	  190196 B/op	    2776 allocs/op
```