### PR TITLE
namespaces config directories by a name (and defaults to… “default”).

### DIFF
--- a/cmd/dangerouscleaner.go
+++ b/cmd/dangerouscleaner.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var forceDestroy bool
+var namespaceToDestroy string
+
+var destroyCmd = &cobra.Command{
+	Use:   "destroy",
+	Short: "this command will wipe out wallets, keys, etc for any namespace (the whole namespace). use caution.",
+	Run: func(cmd *cobra.Command, args []string) {
+		if namespaceToDestroy == "" {
+			fmt.Println("you must specify the namespace to destroy using the --namespace flag")
+			os.Exit(1)
+		}
+
+		if !forceDestroy {
+			fmt.Println("you must specify the --force flag in order to execute this dangerous operation. Selected namesapce:", namespaceToDestroy)
+			os.Exit(1)
+		}
+
+		configNamespace = namespaceToDestroy
+
+		fmt.Println("destroy namespace", namespaceToDestroy)
+
+		// leave the configDir argument empty in order to get the parent namespace directory
+		path := configDir("")
+		fmt.Println("removing path", path)
+		err := os.RemoveAll(path)
+		if err != nil {
+			panic(fmt.Errorf("error removing path: %v", err))
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(destroyCmd)
+	destroyCmd.Flags().BoolVar(&forceDestroy, "force", false, "make sure you really want to drop everything and then specify force here")
+	destroyCmd.Flags().StringVar(&namespaceToDestroy, "namespace", "", "which namespace do you want to destroy")
+}

--- a/cmd/rpcserver.go
+++ b/cmd/rpcserver.go
@@ -69,12 +69,12 @@ func loadPrivateKeyFile(path string) ([]*PrivateKeySet, error) {
 }
 
 func loadLocalKeys(num int) ([]*PrivateKeySet, []*PublicKeySet, error) {
-	privateKeys, err := loadPrivateKeyFile(localConfig)
+	privateKeys, err := loadPrivateKeyFile(configDir(localConfigName))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error loading private keys: %v", err)
 	}
 
-	publicKeys, err := loadPublicKeyFile(localConfig)
+	publicKeys, err := loadPublicKeyFile(configDir(localConfigName))
 	if err != nil {
 		return nil, nil, fmt.Errorf("error loading public keys: %v", err)
 	}
@@ -89,7 +89,7 @@ func loadLocalKeys(num int) ([]*PrivateKeySet, []*PublicKeySet, error) {
 		combinedPrivateKeys := append(privateKeys, extraPrivateKeys...)
 		combinedPublicKeys := append(publicKeys, extraPublicKeys...)
 
-		err = writeJSONKeys(combinedPrivateKeys, combinedPublicKeys, localConfig)
+		err = writeJSONKeys(combinedPrivateKeys, combinedPublicKeys, configDir(localConfigName))
 		if err != nil {
 			return nil, nil, fmt.Errorf("error writing extra node keys: %v", err)
 		}
@@ -171,7 +171,7 @@ func setupLocalNetwork(ctx context.Context, nodeCount int) *gossip3types.NotaryG
 
 	for _, keys := range privateKeys {
 		log.Info("setting up gossip node")
-		setupLocalSigner(ctx, group, keys.EcdsaHexPrivateKey, keys.BlsHexPrivateKey, localConfig)
+		setupLocalSigner(ctx, group, keys.EcdsaHexPrivateKey, keys.BlsHexPrivateKey, configDir(localConfigName))
 	}
 
 	for _, signer := range group.AllSigners() {


### PR DESCRIPTION
Also adds a destroy command which will wipe out a config directory. This will be really useful for tests where the tests won't clobber installs etc. A next iteration of this might let you specify the config directory instead of only using the os default location... but I think this will get us pretty far.