### PR TITLE
Dockerfile: Upgrade Go, use Alpine, fix image entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10.1 AS build
+FROM golang:1.11.5 AS build
 
 WORKDIR /go/src/github.com/quorumcontrol/tupelo
 
@@ -6,11 +6,13 @@ COPY . .
 
 RUN go install -v -a -ldflags '-extldflags "-static"' -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH
 
-FROM debian:stretch-slim
+FROM alpine:3.9
+LABEL maintainer="dev@quroumcontrol.com"
+
 RUN mkdir -p /var/lib/tupelo
 
 WORKDIR /var/lib/tupelo
 
 COPY --from=build /go/bin/tupelo /usr/bin/tupelo
 
-CMD ["bash"]
+ENTRYPOINT ["/usr/bin/tupelo"]


### PR DESCRIPTION
Update the Dockerfile by upgrading Go, using Alpine as base image and fixing the image entrypoint.