### PR TITLE
Add docker build & hub push with github actions

### DIFF
--- a/.github/actions/dep/Dockerfile
+++ b/.github/actions/dep/Dockerfile
@@ -1,0 +1,28 @@
+FROM golang:1.11.5
+
+LABEL "com.github.actions.name"="Golang Dep"
+LABEL "com.github.actions.description"="Run dep ensure with access to private repos"
+LABEL "com.github.actions.icon"="download"
+LABEL "com.github.actions.color"="purple"
+
+SHELL ["/bin/bash", "-c"]
+
+RUN mkdir -p ~/.ssh && \
+    ssh-keyscan -t rsa github.com > github.pub && \
+    diff <(ssh-keygen -lf github.pub) <(echo "2048 SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8 github.com (RSA)") && \
+    cat github.pub >> ~/.ssh/known_hosts && \
+    rm -f github.pub
+
+RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+
+ADD entrypoint.sh /entrypoint.sh
+
+RUN chmod +x /entrypoint.sh
+
+ENV DEPPROJECTROOT=/github/workspace
+
+WORKDIR /github/workspace
+
+ENTRYPOINT ["/entrypoint.sh"]
+
+CMD ["ensure"]

--- a/.github/actions/dep/entrypoint.sh
+++ b/.github/actions/dep/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ ! -z "$SSH_PRIVATE_KEY" ]]; then
+  mkdir -p /ssh
+  echo "$SSH_PRIVATE_KEY" > /ssh/id_rsa
+  chmod 600 /ssh/id_rsa
+  eval "$(ssh-agent -s)" > /dev/null 2>&1
+  ssh-add /ssh/id_rsa > /dev/null 2>&1
+fi
+
+exec /go/bin/dep "$@"

--- a/.github/actions/docker-delete-tag/Dockerfile
+++ b/.github/actions/docker-delete-tag/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine 
+
+LABEL "com.github.actions.name"="Docker Delete Tag"
+LABEL "com.github.actions.description"="Deletes docker tag on docker hub"
+LABEL "com.github.actions.icon"="delete"
+LABEL "com.github.actions.color"="red"
+
+RUN apk --no-cache add curl jq bash
+
+ADD entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/.github/actions/docker-delete-tag/entrypoint.sh
+++ b/.github/actions/docker-delete-tag/entrypoint.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+REPO=$1
+
+if [[ -z "$REPO" ]]; then
+  echo "Must provide repo as command"
+  exit 1
+fi
+
+if [[ -z "$GITHUB_EVENT_PATH" ]]; then
+  echo "\$GITHUB_EVENT_PATH" not found
+  exit 1
+fi
+
+TAG_FULL=$(jq --raw-output ".ref" "$GITHUB_EVENT_PATH")
+# mimic https://github.com/actions/docker/blob/b12ae68bebbb2781edb562c0260881a3f86963b4/tag/tag.rb#L39
+TAG=`echo $TAG_FULL | rev | cut -d / -f 1 | rev`
+
+if [[ -z "$TAG" ]]; then
+  echo "Tag could not be parsed from $GITHUB_EVENT_PATH"
+  exit 1
+fi
+
+TOKEN=`curl -s -H "Content-Type: application/json" -X POST -d '{"username": "'$DOCKER_USERNAME'", "password": "'$DOCKER_PASSWORD'"}' https://hub.docker.com/v2/users/login/ | jq -r .token`
+
+URL="https://hub.docker.com/v2/repositories/${REPO}/tags/${TAG}/"
+
+STATUS_CODE=`curl -s -o request.out \
+-w "%{http_code}" \
+-X DELETE \
+-H "Authorization: JWT ${TOKEN}" \
+"${URL}"`
+
+if [[ $STATUS_CODE == "204" ]]; then
+  exit 0
+else
+  echo $URL
+  echo $STATUS_CODE
+  cat request.out
+  exit 1
+fi

--- a/.github/main.workflow
+++ b/.github/main.workflow
@@ -1,0 +1,59 @@
+workflow "Docker Build & Push" {
+  on = "push"
+  resolves = [
+    "Docker Push Ref Image",
+    "Docker Tag Images",
+  ]
+}
+
+action "Private Dep Ensure" {
+  uses = "./.github/actions/dep"
+  secrets = ["SSH_PRIVATE_KEY"]
+}
+
+action "Docker Login" {
+  uses = "actions/docker/login@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  secrets = ["DOCKER_PASSWORD", "DOCKER_USERNAME"]
+  needs = ["Private Dep Ensure"]
+}
+
+action "Docker Build Container" {
+  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  args = "build -t imagebuild ."
+  needs = ["Docker Login"]
+}
+
+action "Docker Tag Images" {
+  uses = "actions/docker/tag@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  args = "imagebuild quorumcontrol/tupelo"
+  needs = ["Docker Build Container"]
+}
+
+action "Docker Push Release Image" {
+  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  needs = ["Docker Tag Images"]
+  args = "push quorumcontrol/tupelo:${GITHUB_REF}"
+}
+
+action "Docker Push SHA Image" {
+  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  needs = ["Docker Tag Images"]
+  args = "push quorumcontrol/tupelo:${IMAGE_SHA}"
+}
+
+action "Docker Push Ref Image" {
+  uses = "actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108"
+  needs = ["Docker Tag Images"]
+  args = "push quorumcontrol/tupelo:${IMAGE_REF}"
+}
+
+workflow "Docker Tag Deletion" {
+  on = "delete"
+  resolves = ["Docker Delete Tag"]
+}
+
+action "Docker Delete Tag" {
+  uses = "./.github/actions/docker-delete-tag"
+  secrets = ["DOCKER_USERNAME", "DOCKER_PASSWORD"]
+  args = "quorumcontrol/tupelo"
+}


### PR DESCRIPTION
This adds automatic docker image building for every branch (including releases) and pushes them to docker hub. If a branch or tag is deleted, the tag is also deleted from docker hub.


Overall I'm impressed with github actions - being able to just have a bunch of docker images as pipeline steps is amazing. Definitely some limitations on actually running a docker suite inside a github action, but we can still call out to a CI provider inside these steps easily