### PR TITLE
Return error if attempting to SET_DATA on '/'

### DIFF
--- a/consensus/transactions.go
+++ b/consensus/transactions.go
@@ -56,14 +56,19 @@ func complexType(obj interface{}) bool {
 
 func DecodePath(path string) ([]string, error) {
 	trimmed := strings.TrimPrefix(path, "/")
+
+	if trimmed == "" {
+		return []string{}, nil
+	}
+
 	split := strings.Split(trimmed, "/")
-	if len(split) > 1 { // []string{""} is the only valid path with an empty string
-		for _, component := range split {
-			if component == "" {
-				return nil, fmt.Errorf("malformed path string containing repeated separator: %s", path)
-			}
+
+	for _, component := range split {
+		if component == "" {
+			return nil, fmt.Errorf("malformed path string containing repeated separator: %s", path)
 		}
 	}
+
 	return split, nil
 }
 
@@ -78,6 +83,10 @@ func SetDataTransaction(tree *dag.Dag, transaction *chaintree.Transaction) (newT
 	path, err := DecodePath(payload.Path)
 	if err != nil {
 		return nil, false, &ErrorCode{Code: ErrUnknown, Memo: fmt.Sprintf("error decoding path: %v", err)}
+	}
+
+	if len(path) == 0 {
+		return nil, false, &ErrorCode{Code: 999, Memo: "can not replace root object"}
 	}
 
 	if path[0] == "_tupelo" {

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -286,11 +286,11 @@ func TestDecodePath(t *testing.T) {
 
 	dp6, err := DecodePath("")
 	assert.Nil(t, err)
-	assert.Equal(t, []string{""}, dp6)
+	assert.Equal(t, []string{}, dp6)
 
 	dp7, err := DecodePath("/")
 	assert.Nil(t, err)
-	assert.Equal(t, []string{""}, dp7)
+	assert.Equal(t, []string{}, dp7)
 
 	dp8, err := DecodePath("/_tupelo")
 	assert.Nil(t, err)


### PR DESCRIPTION
@cap10morgan and I were discussing in keybase, but I figured its a small change so better to move here for proposal / discussion.

See: https://trello.com/c/R3Fz55ZD/117-bug-setdata-via-rpc-server-with-object-on-root-produces-empty-key

In calling `SET_DATA` from js through rpc-server, when using a key of "/", "", or null and an object as the value, all 3 keys produce a tree with an "" key at the top level with object nested inside of it:

Example:
```node
client.setData(chainId, keyAddr, "/", {"issued": {}, "revoked": {}})
```
```json
{
  "id": "did:tupelo:0x6eaE4054b021BDf754051d79D8c3bb9C333c0b8A",
  "tree": {
    "": {
      "issued": {...},
      "revoked": {...}
      }
    }
  },
  "chain": { ... }
}
```

The proposed solution is to return an error if attempting to call SET_DATA on `/`. First off, we don't want `_tupelo` to be overwritten in the chaintree - calling SET_DATA and then seeing that key persisted, but no other keys from the previous root existed is odd behavior. Second, every time and object is passed to `SET_DATA`, its stored as a link - however in this case, the implementation would lead to setting each key individually on a root object, which would be inconsistent. 

Another route here would be to change our data structure to be `tree: { _tupelo: {}, data: {}}`, and interactions of setting data would always be inside the nested object of data. Then, if you wanted to, you could do a full replacement (or delete & create) of `data` without any mangling.