### PR TITLE
Fix docker-compose for Dockerfile changes

### DIFF
--- a/docker-compose-benchmark.yml
+++ b/docker-compose-benchmark.yml
@@ -4,8 +4,8 @@ services:
     build: .
     volumes:
       - ./cmd/testnode-local-keys:/bootstrap-keys
-    command: ["/usr/bin/tupelo", "benchmark", "-k", "/bootstrap-keys", "-c", "2", "-s", "tps", "-t", "60"]
+    command: ["benchmark", "-k", "/bootstrap-keys", "-c", "2", "-i", "60", "-s", "tps", "-t", "65"]
     environment:
       TUPELO_NODE_BLS_KEY_HEX: "0x2359ac18000fabc4eb17f94995a6507ee10f2845d6f2399679c66a1a4d0ae98e"
       TUPELO_NODE_ECDSA_KEY_HEX: "0x584e484ec64007e30e55aeaf61d627a98af094608a43006a7d98bfd019df5995"
-      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
+      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/QmW2hgZqe6UcQ6kTaF8kS6CA3RDo7wbCvnGctCetbSt85n"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   bootstrap:
     build: .
-    command: ["/usr/bin/tupelo", "bootstrap-node", "-k", "/bootstrap-keys", "-p", "34001"]
+    command: ["bootstrap-node", "-p", "34001"]
     environment:
       TUPELO_NODE_BLS_KEY_HEX: "0x1ef1cf13d52b2dbf3134d7fff6aa617c5cdac42ed89bd20007bfc93d00f0d0c6"
       TUPELO_NODE_ECDSA_KEY_HEX: "0xe2c0b170c56ff0bf08c7376f1ca4bd5cbe481a85f6cdb3de609863e25dce613a"
@@ -16,40 +16,40 @@ services:
     volumes:
       # - .storage:/var/lib/tupelo/.storage:delegated
       - ./cmd/testnode-local-keys:/bootstrap-keys
-    command: ["/usr/bin/tupelo", "test-node", "-k", "/bootstrap-keys"]
+    command: ["test-node", "-k", "/bootstrap-keys"]
     environment:
       TUPELO_NODE_BLS_KEY_HEX: "0x74602d5c6265e53c643319309b94ee31294c63696a498735fb7d0d4d04ed862a"
       TUPELO_NODE_ECDSA_KEY_HEX: "0x44265d8560374e7febc3ab15919f3576a7edf7010728254093b7db08b7269b34"
-      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
+      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/QmW2hgZqe6UcQ6kTaF8kS6CA3RDo7wbCvnGctCetbSt85n"
   node1:
     build: .
     volumes:
       # - .storage:/var/lib/tupelo/.storage:delegated
       - ./cmd/testnode-local-keys:/bootstrap-keys
-    command: ["/usr/bin/tupelo", "test-node", "-k", "/bootstrap-keys"]
+    command: ["test-node", "-k", "/bootstrap-keys"]
     environment:
       TUPELO_NODE_BLS_KEY_HEX: "0x21b41a603769a2bfe73b0c98a95ef336b749d8afd882a641a234fd193465b5dc"
       TUPELO_NODE_ECDSA_KEY_HEX: "0xbe65d548d1c6697ab7a43f9c1e4611bfbc835b5ba49b74e1b3f5745601521a8a"
-      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
+      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/QmW2hgZqe6UcQ6kTaF8kS6CA3RDo7wbCvnGctCetbSt85n"
   node2:
     build: .
     volumes:
       # - .storage:/var/lib/tupelo/.storage:delegated
       - ./cmd/testnode-local-keys:/bootstrap-keys
-    command: ["/usr/bin/tupelo", "test-node", "-k", "/bootstrap-keys"]
+    command: ["test-node", "-k", "/bootstrap-keys"]
     environment:
       TUPELO_NODE_BLS_KEY_HEX: "0x2359ac18000fabc4eb17f94995a6507ee10f2845d6f2399679c66a1a4d0ae98e"
       TUPELO_NODE_ECDSA_KEY_HEX: "0x584e484ec64007e30e55aeaf61d627a98af094608a43006a7d98bfd019df5995"
-      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
+      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/QmW2hgZqe6UcQ6kTaF8kS6CA3RDo7wbCvnGctCetbSt85n"
   rpc-server:
     build: .
     volumes:
       - ./cmd/testnode-local-keys:/bootstrap-keys
-    command: ["/usr/bin/tupelo", "rpc-server", "-k", "/bootstrap-keys"]
+    command: ["rpc-server", "-k", "/bootstrap-keys"]
     environment:
       TUPELO_NODE_BLS_KEY_HEX: "0x2359ac18000fabc4eb17f94995a6507ee10f2845d6f2399679c66a1a4d0ae98e"
       TUPELO_NODE_ECDSA_KEY_HEX: "0x584e484ec64007e30e55aeaf61d627a98af094608a43006a7d98bfd019df5995"
-      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
+      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/QmW2hgZqe6UcQ6kTaF8kS6CA3RDo7wbCvnGctCetbSt85n"
     ports:
       - "50051:50051"
 


### PR DESCRIPTION
This makes the `docker-compose*.yml` files compatible with the changes from https://github.com/quorumcontrol/tupelo/pull/156

Also, the bootstrap node address changed - not 100% sure why. Either our docker-compose.yml is just out of date, or the underlying ipfs libs changed how the node generates its address.