### PR TITLE
Fix empty path ("" or /) parsing on path resolution

### DIFF
--- a/consensus/transactions.go
+++ b/consensus/transactions.go
@@ -57,14 +57,19 @@ func complexType(obj interface{}) bool {
 
 func DecodePath(path string) ([]string, error) {
 	trimmed := strings.TrimPrefix(path, "/")
+
+	if trimmed == "" {
+		return []string{}, nil
+	}
+
 	split := strings.Split(trimmed, "/")
-	if len(split) > 1 { // []string{""} is the only valid path with an empty string
-		for _, component := range split {
-			if component == "" {
-				return nil, fmt.Errorf("malformed path string containing repeated separator: %s", path)
-			}
+
+	for _, component := range split {
+		if component == "" {
+			return nil, fmt.Errorf("malformed path string containing repeated separator: %s", path)
 		}
 	}
+
 	return split, nil
 }
 

--- a/consensus/transactions_test.go
+++ b/consensus/transactions_test.go
@@ -294,11 +294,11 @@ func TestDecodePath(t *testing.T) {
 
 	dp6, err := DecodePath("")
 	assert.Nil(t, err)
-	assert.Equal(t, []string{""}, dp6)
+	assert.Equal(t, []string{}, dp6)
 
 	dp7, err := DecodePath("/")
 	assert.Nil(t, err)
-	assert.Equal(t, []string{""}, dp7)
+	assert.Equal(t, []string{}, dp7)
 
 	dp8, err := DecodePath("/_tupelo")
 	assert.Nil(t, err)


### PR DESCRIPTION
https://trello.com/c/R3Fz55ZD

Now that we have `SET_DATA` happening always under `tree/data`, we have choice:
1) allow user to control the value of `tree/data` maybe a full object or a CID to another tree?
2) disallow the user to set `tree/data`, require at least one key in the path 

This implements 1, but I could see either way being valid. 