### PR TITLE
stop the new session too

### DIFF
--- a/wallet/walletrpc/session_test.go
+++ b/wallet/walletrpc/session_test.go
@@ -56,6 +56,8 @@ func TestImportExport(t *testing.T) {
 	err = sessNew.Start("test-new")
 	require.Nil(t, err)
 
+	defer sessNew.Stop()
+
 	importedNew, err := sessNew.ImportChain(export, &adapters.Config{Adapter: "mock"})
 	require.Nil(t, err)
 


### PR DESCRIPTION
I noticed this when trying to fix: https://trello.com/c/IhTULD1R/128-bug-intermittent-test-failure-netoperror

I couldn't repro the failure in trello, but I was getting "too many open files" from running the walletrpc tests. Specifically, the import/export test. This cleans up the import/export failure (which didn't have a trello).