### PR TITLE
fix two broken benchmarks

### DIFF
--- a/gossip3/actors/signaturegenerator_test.go
+++ b/gossip3/actors/signaturegenerator_test.go
@@ -33,8 +33,8 @@ func TestSignatureGenerator(t *testing.T) {
 		switch msg := context.Message().(type) {
 		case *messages.Store:
 			context.Request(validator, &validationRequest{
-				key:       msg.Key,
-				value:     msg.Value,
+				key:   msg.Key,
+				value: msg.Value,
 			})
 		case *messages.SignatureWrapper:
 			fut.PID().Tell(msg)
@@ -84,9 +84,9 @@ func BenchmarkSignatureGenerator(b *testing.B) {
 	require.Nil(b, err)
 	key := crypto.Keccak256(value)
 
-	transWrapper, err := validator.RequestFuture(&messages.Store{
-		Key:   key,
-		Value: value,
+	transWrapper, err := validator.RequestFuture(&validationRequest{
+		key:   key,
+		value: value,
 	}, 1*time.Second).Result()
 	require.Nil(b, err)
 

--- a/gossip3/actors/validator_test.go
+++ b/gossip3/actors/validator_test.go
@@ -22,8 +22,8 @@ func TestValidator(t *testing.T) {
 		switch msg := context.Message().(type) {
 		case *messages.Store:
 			context.Request(validator, &validationRequest{
-				key:       msg.Key,
-				value:     msg.Value,
+				key:   msg.Key,
+				value: msg.Value,
 			})
 		case *messages.TransactionWrapper:
 			fut.PID().Tell(msg)
@@ -61,9 +61,9 @@ func BenchmarkValidator(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		f := validator.RequestFuture(&messages.Store{
-			Key:   key,
-			Value: value,
+		f := validator.RequestFuture(&validationRequest{
+			key:   key,
+			value: value,
 		}, 5*time.Second)
 		futures[i] = f
 	}


### PR DESCRIPTION
noticed this while making the other benchmark, these two were using the wrong message type and so were timing out.