### PR TITLE
Add version subcommand

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ vendor
 _old
 /tupelo
 /release/
+/resources/templates/
+/VERSION_GUARD_*
+/packrd/
+*-packr.go

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -38,6 +38,14 @@
   revision = "0d2db0f2915c63ee18832b7ed7216d80b1019bc9"
 
 [[projects]]
+  digest = "1:e4b30804a381d7603b8a344009987c1ba351c26043501b23b8c7ce21f0b67474"
+  name = "github.com/BurntSushi/toml"
+  packages = ["."]
+  pruneopts = ""
+  revision = "3012a1dbe2e4bd1391d42b32f0577cb7bbc7f005"
+  version = "v0.3.1"
+
+[[projects]]
   digest = "1:631c9e9dc0894d1b7ba7d9f2a0120f60cc8478a1769b23b8a04a16b824c7322d"
   name = "github.com/Workiva/go-datastructures"
   packages = [
@@ -297,6 +305,119 @@
   pruneopts = ""
   revision = "2fee6af1a9795aafbe0253a0cfbdf668e1fb8a9a"
   version = "v1.8.0"
+
+[[projects]]
+  digest = "1:b94fcd9abf76b6bfa217b514de3f3fa4c7ed74386afa6404470379bbf1311f61"
+  name = "github.com/gobuffalo/buffalo-plugins"
+  packages = [
+    "plugins",
+    "plugins/plugdeps",
+  ]
+  pruneopts = ""
+  revision = "69f3d62dac4196808a821b63b783789d30aadffc"
+  version = "v1.13.1"
+
+[[projects]]
+  digest = "1:83e42cd058ee568f8897de6fb1ec66ba5751ab88436e8d9759824502a9fbed27"
+  name = "github.com/gobuffalo/envy"
+  packages = ["."]
+  pruneopts = ""
+  revision = "fa0dfdc10b5366ce365b7d9d1755a03e4e797bc5"
+  version = "v1.6.15"
+
+[[projects]]
+  digest = "1:a5dca36731ffa1021ff07ab46ab90d3e41bec9fb91faf9568c2cf2035ab91356"
+  name = "github.com/gobuffalo/events"
+  packages = ["."]
+  pruneopts = ""
+  revision = "7405490b2bb796f2d6aaea94f4c8692e67aa7086"
+  version = "v1.2.0"
+
+[[projects]]
+  digest = "1:090dc6cf3385775be560c3a51729681ec5abf45cabdee39734782af67a0413fe"
+  name = "github.com/gobuffalo/flect"
+  packages = [
+    ".",
+    "name",
+  ]
+  pruneopts = ""
+  revision = "d4fc286952bf96d0262a67b482e234613ae36f59"
+  version = "v0.1.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:a0cb3739b4307634b60b7b05e59893cd8a466d65218638af58fcc05a6a069618"
+  name = "github.com/gobuffalo/genny"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f262bb0c783b26032e1df7c9c3da8ad470a79d1a"
+
+[[projects]]
+  branch = "master"
+  digest = "1:0a50c9400aae50639eb9afbb54f440f4775836fc8e77a956d3da6c65983b8f30"
+  name = "github.com/gobuffalo/gogen"
+  packages = [
+    ".",
+    "goimports",
+    "gomods",
+  ]
+  pruneopts = ""
+  revision = "1c6076128bbc66ac8068c0c685f0848287b7c360"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ed45ebb9e9ed6696a4eae0b964e4e696e0022ac4ccff5d25e97dea2566b35a56"
+  name = "github.com/gobuffalo/logger"
+  packages = ["."]
+  pruneopts = ""
+  revision = "be78ebfea0fa04f089e4fab7d3388315dbe89a0a"
+
+[[projects]]
+  digest = "1:393b559d395e7ad075eb04fbc52bc2546a25d5ac129f4fccaf56bb133a6c77d3"
+  name = "github.com/gobuffalo/mapi"
+  packages = ["."]
+  pruneopts = ""
+  revision = "09ac528b16b7e871fe0f14d4867a07820a30a14b"
+  version = "v1.0.1"
+
+[[projects]]
+  branch = "master"
+  digest = "1:453ce928d39632c6d52dad0117ecebc49cf4c30f48de36e0e48b2aae1576c709"
+  name = "github.com/gobuffalo/meta"
+  packages = ["."]
+  pruneopts = ""
+  revision = "50a99e08b8cf340b099048d2ad70bf525f2e16a7"
+
+[[projects]]
+  branch = "master"
+  digest = "1:4dc3a807179b54e44ee710e30cae87ea4ba5f3ee6b96a1929ab8042ece05fe19"
+  name = "github.com/gobuffalo/packd"
+  packages = ["."]
+  pruneopts = ""
+  revision = "d04dd98aca5b9aa7ca7c36ee639a21bcc69de32a"
+
+[[projects]]
+  digest = "1:169b0f13452aa130cad334e8398aa8358759ab96e4d045bd8b6cba3e27ccda4d"
+  name = "github.com/gobuffalo/packr"
+  packages = [
+    "v2",
+    "v2/file",
+    "v2/file/resolver",
+    "v2/file/resolver/encoding/hex",
+    "v2/jam/parser",
+    "v2/plog",
+  ]
+  pruneopts = ""
+  revision = "5aa3f2df6770adb7f8719a43ef25c2522af176ed"
+  version = "v2.0.3"
+
+[[projects]]
+  branch = "master"
+  digest = "1:03179c4a6eecf90cbfbb07648e6202dd999904531c9757ba034f009904de3a9c"
+  name = "github.com/gobuffalo/syncx"
+  packages = ["."]
+  pruneopts = ""
+  revision = "33c29581e754bd354236e977dfe426e55331c45d"
 
 [[projects]]
   digest = "1:527e1e468c5586ef2645d143e9f5fbd50b4fe5abc8b1e25d9f1c416d22d24895"
@@ -826,6 +947,30 @@
   revision = "aac704a3f4f27190b4ccc05f303a4931fd1241ff"
 
 [[projects]]
+  digest = "1:7df5a9695a743c3e1626b28bb8741602c8c15527e1efaeaec48ab2ff9a23f74c"
+  name = "github.com/joho/godotenv"
+  packages = ["."]
+  pruneopts = ""
+  revision = "23d116af351c84513e1946b527c88823e476be13"
+  version = "v1.3.0"
+
+[[projects]]
+  digest = "1:efd715c5992bad73b911a42d2fa536a89f5d6928cd967abc8a1104fd175a2b0d"
+  name = "github.com/karrick/godirwalk"
+  packages = ["."]
+  pruneopts = ""
+  revision = "6d1c7760ec857d2984abe0a23fa263877f50d3f0"
+  version = "v1.8.0"
+
+[[projects]]
+  digest = "1:0f51cee70b0d254dbc93c22666ea2abf211af81c1701a96d04e2284b408621db"
+  name = "github.com/konsorten/go-windows-terminal-sequences"
+  packages = ["."]
+  pruneopts = ""
+  revision = "f55edac94c9bbba5d6182a4be46d86a2c9b5b50e"
+  version = "v1.0.2"
+
+[[projects]]
   branch = "master"
   digest = "1:560e150c2fcf04a92c22029205edb57cd0282a545dd949165dae5cd65bce1204"
   name = "github.com/lucas-clemente/aes12"
@@ -848,6 +993,22 @@
   pruneopts = ""
   revision = "c2353362d570a7bfa228149c62842019201cfb71"
   version = "v1.8.0"
+
+[[projects]]
+  branch = "master"
+  digest = "1:ff3d3a7e367bf58b25e3c9203b7e82a02b2bfa220eacb2b362c0dbc3fcffa15b"
+  name = "github.com/markbates/oncer"
+  packages = ["."]
+  pruneopts = ""
+  revision = "bf2de49a0be218916e69a11d22866e6cd0a560f2"
+
+[[projects]]
+  digest = "1:3f2db5df3a9970a9f0ecab2cbce60f845894ed14f4c6b13859d8d2add7919302"
+  name = "github.com/markbates/safe"
+  packages = ["."]
+  pruneopts = ""
+  revision = "6fea05a5732486546a4836b7a1d596c5ec687b98"
+  version = "v1.0.1"
 
 [[projects]]
   digest = "1:9ea83adf8e96d6304f394d40436f2eb44c1dc3250d223b74088cc253a6cd0a1c"
@@ -1126,6 +1287,18 @@
   revision = "b614a709649cd8c459f63c2aa20e95ca00a6405d"
 
 [[projects]]
+  digest = "1:d367886e3a8134415fad58fb2ac44e2f38aa88068adca7a02d59a555f87085c0"
+  name = "github.com/rogpeppe/go-internal"
+  packages = [
+    "modfile",
+    "module",
+    "semver",
+  ]
+  pruneopts = ""
+  revision = "1cf9852c553c5b7da2d5a4a091129a7822fed0c9"
+  version = "v1.2.2"
+
+[[projects]]
   digest = "1:5f47c69f85311c4dc292be6cc995a0a3fe8337a6ce38ef4f71e5b7efd5ad42e0"
   name = "github.com/rs/cors"
   packages = ["."]
@@ -1148,6 +1321,14 @@
   packages = ["."]
   pruneopts = ""
   revision = "e180dbdc8da04c4fa04272e875ce64949f38bd3e"
+
+[[projects]]
+  digest = "1:9a3c631555e0351fdc4e696577bb63afd90c399d782a8462dba9d100d7021db3"
+  name = "github.com/sirupsen/logrus"
+  packages = ["."]
+  pruneopts = ""
+  revision = "e1e72e9de974bd926e5c56f83753fba2df402ce5"
+  version = "v1.3.0"
 
 [[projects]]
   digest = "1:633b5b39909d9d794f5543baee4971890e1866f5c082cdf4694954c1ff489a18"
@@ -1323,6 +1504,7 @@
     "salsa20/salsa",
     "scrypt",
     "sha3",
+    "ssh/terminal",
   ]
   pruneopts = ""
   revision = "057139ce5d2bdbe6fe73c53679e24e9cf007f637"
@@ -1400,6 +1582,27 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:f8143d14fe668c91da29575412eb88c15c4acfadf8cfff3692e1c237de8b7053"
+  name = "golang.org/x/tools"
+  packages = [
+    "go/ast/astutil",
+    "go/gcexportdata",
+    "go/internal/cgo",
+    "go/internal/gcimporter",
+    "go/internal/packagesdriver",
+    "go/packages",
+    "go/types/typeutil",
+    "imports",
+    "internal/fastwalk",
+    "internal/gopathwalk",
+    "internal/module",
+    "internal/semver",
+  ]
+  pruneopts = ""
+  revision = "6a08e3108db3c45254bbacc63c70c6addc62e6cb"
+
+[[projects]]
+  branch = "master"
   digest = "1:2255fee1df9431ec9c0a373a4e112a60b28ae435d7af57d69f4f2e2e86800cad"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
@@ -1469,6 +1672,7 @@
     "github.com/ethereum/go-ethereum/common/hexutil",
     "github.com/ethereum/go-ethereum/crypto",
     "github.com/ethereum/go-ethereum/log",
+    "github.com/gobuffalo/packr/v2",
     "github.com/gogo/protobuf/proto",
     "github.com/golang/protobuf/proto",
     "github.com/gorilla/mux",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -61,3 +61,7 @@
 [[constraint]]
   name = "github.com/quorumcontrol/tupelo-go-client"
   revision = "b614a709649cd8c459f63c2aa20e95ca00a6405d"
+
+[[constraint]]
+  name = "github.com/gobuffalo/packr"
+  version = "2.0.3"

--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,32 @@ else
 	TAG = $(VERSION)
 endif
 
+# GUARD is a function which calculates md5 sum for its
+# argument variable name.
+GUARD = $(1)_GUARD_$(shell echo $($(1)) | md5sum | cut -d ' ' -f 1)
+
 FIRSTGOPATH = $(firstword $(subst :, ,$(GOPATH)))
+VERSION_TXT = resources/templates/version.txt
 
 generated = gossip3/messages/internal_gen.go gossip3/messages/internal_gen_test.go
 gosources = $(shell find . -path "./vendor/*" -prune -o -type f -name "*.go" -print)
+packr = packrd/packed-packr.go resources/resources-packr.go
 
 all: tupelo
+
+$(VERSION_TXT): $(call GUARD,VERSION)
+	mkdir -p resources/templates
+	echo $(VERSION) > $@
+
+$(call GUARD,VERSION):
+	rm -rf VERSION_GUARD_*
+	touch $@
+
+$(FIRSTGOPATH)/bin/packr2:
+	go get -u github.com/gobuffalo/packr/v2/packr2
+
+$(packr): $(FIRSTGOPATH)/bin/packr2 $(VERSION_TXT)
+	$(FIRSTGOPATH)/bin/packr2
 
 $(generated): gossip3/messages/internal.go
 	cd gossip3/messages && go generate
@@ -18,22 +38,23 @@ $(generated): gossip3/messages/internal.go
 vendor: Gopkg.toml Gopkg.lock
 	dep ensure
 
-tupelo: vendor $(generated) $(gosources)
+tupelo: vendor $(packr) $(generated) $(gosources)
 	go build
 
-test: vendor $(generated) $(gosources)
+test: vendor $(packr) $(generated) $(gosources)
 	go test ./...
 
-integration-test: vendor $(generated) $(gosources)
+integration-test: vendor $(packr) $(generated) $(gosources)
 	go test ./... -tags=integration
 
-docker-image: vendor Dockerfile .dockerignore
+docker-image: vendor $(packr) $(generated) $(gosources) Dockerfile .dockerignore
 	docker build -t quorumcontrol/tupelo:$(TAG) .
 
-install: vendor $(generated) $(gosources)
+install: vendor $(packr) $(generated) $(gosources)
 	go install -a -gcflags=-trimpath=$(GOPATH) -asmflags=-trimpath=$(GOPATH)
 
 clean:
+	$(FIRSTGOPATH)/bin/packr2 clean
 	go clean
 	rm -rf vendor
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,14 @@ cd into the directory and
 go generate
 ```
 
+## Version
+The version of Tupelo is controlled via the `$VERSION` variable to the Makefile 
+(default: "snapshot"). Make prints this to a file called resources/templates/version.txt,
+which again gets embedded into the binary by the [packr](github.com/gobuffalo/packr) tool.
+
+More specifically, the Makefile ensures that `packr2` gets invoked before building, which
+generates some Go source code to embed templates (i.e. version.txt) into the built binary.
+
 ### Testing
 
 Integration tests are not run by default, add the "integration" tag to run
@@ -26,7 +34,6 @@ these. Also add the path containing the libindy-crypto library as an ldflag so
 the linker can find it:
 
 `go test -tags=integration -ldflags="-r /path/to/libindy-crypto/release" ./...`
-
 
 ## Concepts
 Every asset and actor in the system has their own Chain Tree, a new data structure combining a merkle-DAG and an individual ordered log of transactions. A Chain Tree is similar in concept to Git, but with known transactions on data instead of simple textual manipulation. Functionally, a Chain Tree is a state-machine where the input and resulting state is a content-addressable merkle-DAG. Playing ordered transactions on an existing state produces a new state. 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/quorumcontrol/tupelo/resources"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Get Tupelo version",
+	Run: func(cmd *cobra.Command, _ []string) {
+		version, err := resources.Version()
+		if err != nil {
+			panic(fmt.Sprintf("couldn't load version: %s", err))
+		}
+		fmt.Printf("Tupelo Version: %s\n", version)
+	},
+}

--- a/resources/version.go
+++ b/resources/version.go
@@ -1,0 +1,23 @@
+package resources
+
+import (
+	"strings"
+
+	"github.com/gobuffalo/packr/v2"
+)
+
+var version string
+
+// Version gets the current version.
+func Version() (string, error) {
+	if version != "" {
+		return version, nil
+	}
+
+	box := packr.New("Resources", "./templates")
+	version, err := box.FindString("version.txt")
+	if err == nil {
+		version = strings.TrimSpace(version)
+	}
+	return version, err
+}


### PR DESCRIPTION
Add `version` subcommand to Tupelo. The version is controlled by setting the $VERSION variable when building with make.

**Question**: Should I add a test for the version command?