### PR TITLE
Fix bug that was preventing minting to maximum inclusive

### DIFF
--- a/consensus/transactions.go
+++ b/consensus/transactions.go
@@ -256,7 +256,7 @@ func MintTokenTransaction(tree *dag.Dag, transaction *chaintree.Transaction) (ne
 			currentMintedTotal = currentMintedTotal + amount.(uint64)
 		}
 
-		if (currentMintedTotal + payload.Amount) >= monetaryPolicy.Maximum {
+		if (currentMintedTotal + payload.Amount) > monetaryPolicy.Maximum {
 			return nil, false, &ErrorCode{Code: 999, Memo: fmt.Sprintf("new mint would violate monetaryPolicy of maximum: %v", monetaryPolicy.Maximum)}
 		}
 	}


### PR DESCRIPTION
This fixes a bug with minting where if a monetary policy maximum was set, you could only mint to the `maximum - 1` instead of the full `maximum`.