### PR TITLE
Clean up after stale transactions

### DIFF
--- a/gossip3/actors/tupelo.go
+++ b/gossip3/actors/tupelo.go
@@ -126,12 +126,9 @@ func (tn *TupeloNode) handleNewTransaction(context actor.Context) {
 		if msg.PreFlight || msg.Accepted {
 			tn.conflictSetRouter.Tell(msg)
 		} else {
-			switch stale := msg.Metadata["stale"].(type) {
-			case bool:
-				if stale {
-					tn.Log.Debugw("ignoring and cleaning up stale transaction", "msg", msg)
-				}
-			default:
+			if msg.Stale {
+				tn.Log.Debugw("ignoring and cleaning up stale transaction", "msg", msg)
+			} else {
 				tn.Log.Debugw("removing bad transaction", "msg", msg)
 				var errSource string
 				if msg.Transaction != nil && msg.Transaction.ObjectID != nil {

--- a/gossip3/actors/validator.go
+++ b/gossip3/actors/validator.go
@@ -75,6 +75,7 @@ func (tv *TransactionValidator) handleRequest(context actor.Context, msg *valida
 		Value:     msg.value,
 		PreFlight: false,
 		Accepted:  false,
+		Stale:     false,
 		Metadata:  messages.MetadataMap{"seen": time.Now()},
 	}
 	var t extmsgs.Transaction
@@ -109,7 +110,7 @@ func (tv *TransactionValidator) handleRequest(context actor.Context, msg *valida
 			preFlight = true
 		} else {
 			tv.Log.Debugf("transaction height %d is lower than current state height %d; ignoring", t.Height, expectedHeight)
-			wrapper.Metadata["stale"] = true
+			wrapper.Stale = true
 			context.Respond(wrapper)
 			return
 		}

--- a/gossip3/messages/messages.go
+++ b/gossip3/messages/messages.go
@@ -100,6 +100,7 @@ type TransactionWrapper struct {
 	Transaction   *extmsgs.Transaction
 	PreFlight     bool
 	Accepted      bool
+	Stale         bool
 	Key           []byte
 	Value         []byte
 	Metadata      MetadataMap


### PR DESCRIPTION
@tobowers This seem better?

I wavered on whether or not the stale flag should be in metadata or a first-class struct member, so let me know if you have thoughts on that (or an alternative to both).