### PR TITLE
require a blank history on first transaction

### DIFF
--- a/gossip3/actors/validator_test.go
+++ b/gossip3/actors/validator_test.go
@@ -6,7 +6,11 @@ import (
 
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/quorumcontrol/chaintree/chaintree"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/chaintree/safewrap"
 	"github.com/quorumcontrol/storage"
+	"github.com/quorumcontrol/tupelo-go-client/consensus"
 	extmsgs "github.com/quorumcontrol/tupelo-go-client/gossip3/messages"
 	"github.com/quorumcontrol/tupelo-go-client/gossip3/testhelpers"
 	"github.com/quorumcontrol/tupelo/gossip3/messages"
@@ -45,6 +49,89 @@ func TestValidator(t *testing.T) {
 	})
 
 	_, err = fut.Result()
+	require.Nil(t, err)
+}
+
+func TestCannotFakeOldHistory(t *testing.T) {
+	// this test makes sure that you can't send in old history on the
+	// genesis transaction and get the notary group to approve your first
+	// transaction.
+
+	currentState := storage.NewMemStorage()
+	validator := actor.Spawn(NewTransactionValidatorProps(currentState))
+	defer validator.Poison()
+
+	treeKey, err := crypto.GenerateKey()
+	require.Nil(t, err)
+
+	sw := safewrap.SafeWrap{}
+
+	treeDID := consensus.AddrToDid(crypto.PubkeyToAddress(treeKey.PublicKey).String())
+
+	coinName := "evilTuples"
+
+	unsignedBlock := &chaintree.BlockWithHeaders{
+		Block: chaintree.Block{
+			PreviousTip: nil,
+			Height:      0,
+			Transactions: []*chaintree.Transaction{
+				{
+					Type: "MINT_COIN",
+					Payload: &consensus.MintCoinPayload{
+						Name:   coinName,
+						Amount: 4999,
+					},
+				},
+			},
+		},
+	}
+
+	nodeStore := nodestore.NewStorageBasedStore(storage.NewMemStorage())
+	evilTree := consensus.NewEmptyTree(treeDID, nodeStore)
+
+	path, err := consensus.DecodePath("tree/" + consensus.TreePathForCoins)
+	require.Nil(t, err)
+
+	coinPath := append(path, coinName)
+	monetaryPolicyPath := append(coinPath, "monetaryPolicy")
+
+	evilTree, err = evilTree.SetAsLink(monetaryPolicyPath, &consensus.CoinMonetaryPolicy{
+		Maximum: 5000,
+	})
+	require.Nil(t, err)
+
+	testTree, err := chaintree.NewChainTree(evilTree, nil, consensus.DefaultTransactors)
+	require.Nil(t, err)
+
+	blockWithHeaders, err := consensus.SignBlock(unsignedBlock, treeKey)
+	require.Nil(t, err)
+
+	testTree.ProcessBlock(blockWithHeaders)
+	nodes := dagToByteNodes(t, evilTree)
+
+	bits := sw.WrapObject(blockWithHeaders).RawData()
+	require.Nil(t, sw.Err)
+
+	trans := extmsgs.Transaction{
+		PreviousTip: evilTree.Tip.Bytes(),
+		Height:      blockWithHeaders.Height,
+		NewTip:      testTree.Dag.Tip.Bytes(),
+		Payload:     bits,
+		State:       nodes,
+		ObjectID:    []byte(treeDID),
+	}
+
+	value, err := trans.MarshalMsg(nil)
+	require.Nil(t, err)
+	key := crypto.Keccak256(value)
+
+	fut := validator.RequestFuture(&validationRequest{
+		key:   key,
+		value: value,
+	}, 5*time.Second)
+	isValid, err := fut.Result()
+	require.False(t, isValid.(*messages.TransactionWrapper).Accepted)
+
 	require.Nil(t, err)
 }
 


### PR DESCRIPTION
Previously, you could send in any previous state you wanted on the very first transaction and the notary group would approve. This is dangerous because of what's demonstrated in the test below where I was able to mint a token with an unvalidated establish coin.

This uses a blank state when the currentState is nil instead of just assuming the transaction is ok.