### PR TITLE
Ensure docker-compose bootstrap node doesn't connect testnet bootstrap

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       TUPELO_NODE_BLS_KEY_HEX: "0x1ef1cf13d52b2dbf3134d7fff6aa617c5cdac42ed89bd20007bfc93d00f0d0c6"
       TUPELO_NODE_ECDSA_KEY_HEX: "0xe2c0b170c56ff0bf08c7376f1ca4bd5cbe481a85f6cdb3de609863e25dce613a"
+      # Bootstrap to self so that this node doesn't connect to the remote network
+      TUPELO_BOOTSTRAP_NODES: "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
     networks:
       default:
         ipv4_address: 172.16.238.10


### PR DESCRIPTION
During debugging, noticed the bootstrap node was communicating with the testnet bootstrap nodes. Now, this doesn't fix the timeouts in the benchmarks, but does seem to eliminate the `timeout waiting for remote syncer` pretty quickly after boot.