### PR TITLE
fix bad log message

### DIFF
--- a/cmd/testnode.go
+++ b/cmd/testnode.go
@@ -54,9 +54,7 @@ var testnodeCmd = &cobra.Command{
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 		if err := logging.SetLogLevel("gossip", "ERROR"); err != nil {
-			log.Error("failed to set log level of \"gossip\": %s", err)
-			// TODO: Enable
-			// panic(fmt.Sprintf("failed to set log level of \"gossip\": %s", err))
+			log.Error("failed to set log level of 'gossip'", "err", err)
 		}
 		ecdsaKeyHex := os.Getenv("TUPELO_NODE_ECDSA_KEY_HEX")
 		blsKeyHex := os.Getenv("TUPELO_NODE_BLS_KEY_HEX")


### PR DESCRIPTION
just noticed this while running the local run at "warn" level. The log there is ethereum log and doesn't take a formatted string, it takes k/v pairs.