### PR TITLE
Fix docker build in github

### DIFF
--- a/.github/actions/dep/Dockerfile
+++ b/.github/actions/dep/Dockerfile
@@ -19,10 +19,6 @@ ADD entrypoint.sh /entrypoint.sh
 
 RUN chmod +x /entrypoint.sh
 
-ENV DEPPROJECTROOT=/github/workspace
-
-WORKDIR /github/workspace
-
 ENTRYPOINT ["/entrypoint.sh"]
 
 CMD ["ensure"]

--- a/.github/actions/dep/entrypoint.sh
+++ b/.github/actions/dep/entrypoint.sh
@@ -8,4 +8,12 @@ if [[ ! -z "$SSH_PRIVATE_KEY" ]]; then
   ssh-add /ssh/id_rsa > /dev/null 2>&1
 fi
 
+build_dir=$GOPATH/src/github.com/$GITHUB_REPOSITORY
+
+mkdir -p $(dirname $build_dir)
+
+ln -s $GITHUB_WORKSPACE $build_dir
+
+cd $build_dir
+
 exec /go/bin/dep "$@"


### PR DESCRIPTION
Docker builds are failing in the new protoactor branch because dep is loading in the master version of tupelo which results in type conflicts. This fixes that by running `dep ensure` inside the real gopath: `/go/src/github.com/quorumcontrol/tupelo`.