### PR TITLE
Help pushsyncer not fail quite as much

### DIFF
--- a/gossip3/actors/pushsyncer.go
+++ b/gossip3/actors/pushsyncer.go
@@ -97,7 +97,7 @@ func (syncer *PushSyncer) handleDoPush(context actor.Context, msg *messages.DoPu
 
 	resp, err := context.RequestFuture(remoteGossiper, &messages.GetSyncer{
 		Kind: syncer.kind,
-	}, 60*time.Second).Result()
+	}, 120*time.Second).Result()
 	if err != nil {
 		syncer.Log.Errorw("timeout waiting for remote syncer", "err", err)
 	}


### PR DESCRIPTION
Some band aids for what may ultimately be a protoactor bug. Curious to see if it makes AWS benchmarking go any smoother.