### PR TITLE
stop the syncer after a timeout (and log who we timed out with)

### DIFF
--- a/gossip3/actors/pushsyncer.go
+++ b/gossip3/actors/pushsyncer.go
@@ -99,7 +99,9 @@ func (syncer *PushSyncer) handleDoPush(context actor.Context, msg *messages.DoPu
 		Kind: syncer.kind,
 	}, 120*time.Second).Result()
 	if err != nil {
-		syncer.Log.Errorw("timeout waiting for remote syncer", "err", err)
+		syncer.Log.Errorw("timeout waiting for remote syncer", "err", err, "remote", remoteGossiper.String())
+		context.Self().Stop()
+		return
 	}
 
 	switch remoteSyncer := resp.(type) {


### PR DESCRIPTION
Right now if there was a timeout the pushsyncer would just sit there until the 10second timeout reclaimed it. This makes it stop immediately so the gossiper can initiate another sync.