### PR TITLE
Use Request func when sender is context.Self()

### DIFF
--- a/gossip3/actors/pushsyncer.go
+++ b/gossip3/actors/pushsyncer.go
@@ -116,12 +116,12 @@ func (syncer *PushSyncer) handleDoPush(context actor.Context, msg *messages.DoPu
 			panic("timeout")
 		}
 		syncer.Log.Debugw("providing strata", "remote", destination)
-		context.RequestWithCustomSender(destination, &messages.ProvideStrata{
+		context.Request(destination, &messages.ProvideStrata{
 			Strata: strata.(*ibf.DifferenceStrata),
 			DestinationHolder: messages.DestinationHolder{
 				Destination: extmsgs.ToActorPid(syncer.storageActor),
 			},
-		}, context.Self())
+		})
 	default:
 		syncer.Log.Errorw("unknown response type", "remoteSyncer", remoteSyncer)
 	}
@@ -204,12 +204,12 @@ func (syncer *PushSyncer) handleRequestIBF(context actor.Context, msg *messages.
 		panic("timeout")
 	}
 
-	context.RequestWithCustomSender(context.Sender(), &messages.ProvideBloomFilter{
+	context.Request(context.Sender(), &messages.ProvideBloomFilter{
 		Filter: localIBF,
 		DestinationHolder: messages.DestinationHolder{
 			Destination: extmsgs.ToActorPid(syncer.storageActor),
 		},
-	}, context.Self())
+	})
 }
 
 func (syncer *PushSyncer) handleProvideBloomFilter(context actor.Context, msg *messages.ProvideBloomFilter) {
@@ -268,7 +268,7 @@ func (syncer *PushSyncer) syncDone(context actor.Context) {
 	sender := context.Sender()
 	syncer.Log.Debugw("sending sync complete", "remote", sender)
 	if sender != nil {
-		context.RequestWithCustomSender(context.Sender(), &messages.SyncDone{}, context.Self())
+		context.Request(context.Sender(), &messages.SyncDone{})
 	}
 	context.Self().Poison()
 }


### PR DESCRIPTION
...instead of RequestWithCustomSender. `context.Self()` is the default sender so we don't need to specify it as a custom sender.