### PR TITLE
Remove protoactor-go version constraint

### DIFF
--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -55,10 +55,6 @@
   version = "v1.0.27"
 
 [[constraint]]
-  name = "github.com/AsynkronIT/protoactor-go"
-  revision = "0d2db0f2915c63ee18832b7ed7216d80b1019bc9"
-
-[[constraint]]
   name = "github.com/quorumcontrol/tupelo-go-client"
   revision = "b614a709649cd8c459f63c2aa20e95ca00a6405d"
 


### PR DESCRIPTION
We believe the behavior we saw that motivated adding this in the first
place was actually a red herring; an intermittent bug that happened to
occur before this change was made and then did not re-occr after it was
made for two of us.

It should (hopefully) just use the version that the client lib brings
in.