### PR TITLE
remove bad watch line

### DIFF
--- a/gossip3/actors/gossiper.go
+++ b/gossip3/actors/gossiper.go
@@ -111,7 +111,6 @@ func (g *Gossiper) Receive(context actor.Context) {
 		g.Log.Debugw("GetSyncer", "remote", context.Sender().GetId())
 		if g.syncersAvailable > 0 {
 			receiveSyncer := context.SpawnPrefix(g.pusherProps, remoteSyncerPrefix)
-			context.Watch(receiveSyncer)
 			g.syncersAvailable--
 			available := &messages.SyncerAvailable{}
 			available.SetDestination(extmsgs.ToActorPid(receiveSyncer))


### PR DESCRIPTION
I wanted this to be a separate PR. It could definitely have something to do with the timeouts.

Adding this watch, sends the Terminate message twice which means the syncersAvailable count goes up by 2 for every one that's removed... in traces I was seeing counts of 500+ syncersAvailable which means in practice a signer would never say it was too busy which could cause a bunch of problems.

I think this line was added *after* the timeout investigation started so I don't believe it fixes it, but it could be that it was masking a fix we had already made.
