### PR TITLE
Fix docker container certs for latest-release filter

### DIFF
--- a/.github/actions/filters/Dockerfile
+++ b/.github/actions/filters/Dockerfile
@@ -7,7 +7,7 @@ LABEL "com.github.actions.color"="gray-dark"
 
 RUN apt-get update && \
     apt-get install --no-install-recommends -y \
-      curl jq && \
+      curl jq ca-certificates && \
 	  apt-get clean -y && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Noticed `latest` tag on docker hub wasn't updated after friday's release. Issue was no certs - https://github.com/quorumcontrol/tupelo/runs/83327045.