### PR TITLE
upgrade tupelo-go-client for bridge race condition

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1318,8 +1318,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:95ac8283490badafa44997f7dd622245ef8cc2cd6560d304555b43a90dd199e9"
+  digest = "1:847f045ae7471febd531b836ca4f555bc7ce718ccfd5e77ed8fa28b6a9f6d28a"
   name = "github.com/quorumcontrol/tupelo-go-client"
   packages = [
     "bls",
@@ -1334,7 +1333,7 @@
     "tracing",
   ]
   pruneopts = ""
-  revision = "b6794c8e414acbe8e2fd8f905803e6d1939517e3"
+  revision = "cf5a1487e6ed4bd9c09ab4fcb3552afb4175fa05"
 
 [[projects]]
   digest = "1:d367886e3a8134415fad58fb2ac44e2f38aa88068adca7a02d59a555f87085c0"
@@ -1814,7 +1813,6 @@
     "github.com/ethereum/go-ethereum/crypto",
     "github.com/ethereum/go-ethereum/log",
     "github.com/gobuffalo/packr/v2",
-    "github.com/gobuffalo/packr/v2/file/resolver",
     "github.com/gogo/protobuf/proto",
     "github.com/golang/protobuf/proto",
     "github.com/gorilla/mux",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@
 
 [[constraint]]
   name = "github.com/quorumcontrol/tupelo-go-client"
-  revision = "b6794c8e414acbe8e2fd8f905803e6d1939517e3"
+  revision = "cf5a1487e6ed4bd9c09ab4fcb3552afb4175fa05"
 
 [[constraint]]
   name = "github.com/gobuffalo/packr"


### PR DESCRIPTION
This pulls in https://github.com/quorumcontrol/tupelo-go-client/pull/16 