### PR TITLE
Update tupelo-go-client for specifying libp2p ip

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1318,8 +1318,7 @@
   version = "v1.1.1"
 
 [[projects]]
-  branch = "master"
-  digest = "1:847f045ae7471febd531b836ca4f555bc7ce718ccfd5e77ed8fa28b6a9f6d28a"
+  digest = "1:776489be502f74243fec306d1bf30b9638d6f5e6ac8c0cb7c93fae869c31c6eb"
   name = "github.com/quorumcontrol/tupelo-go-client"
   packages = [
     "bls",
@@ -1334,7 +1333,7 @@
     "tracing",
   ]
   pruneopts = ""
-  revision = "cf5a1487e6ed4bd9c09ab4fcb3552afb4175fa05"
+  revision = "0b411046e79b62cbb0631c3d3d63490faedcaaf3"
 
 [[projects]]
   digest = "1:d367886e3a8134415fad58fb2ac44e2f38aa88068adca7a02d59a555f87085c0"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -56,7 +56,7 @@
 
 [[constraint]]
   name = "github.com/quorumcontrol/tupelo-go-client"
-  revision = "cf5a1487e6ed4bd9c09ab4fcb3552afb4175fa05"
+  revision = "0b411046e79b62cbb0631c3d3d63490faedcaaf3"
 
 [[constraint]]
   name = "github.com/gobuffalo/packr"


### PR DESCRIPTION
See https://github.com/quorumcontrol/tupelo-go-client/pull/19