### PR TITLE
Fix Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM golang:1.11.5 AS build
 
-WORKDIR /go/src/github.com/quorumcontrol/tupelo
+WORKDIR /app
 
 COPY . .
 
-RUN go install -v -a -ldflags '-extldflags "-static"' -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH
+RUN go install -mod=vendor -v -a -ldflags '-extldflags "-static"' -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH
 
 FROM alpine:3.9
 LABEL maintainer="dev@quroumcontrol.com"


### PR DESCRIPTION
Fix the Dockerfile, as it turns out to be broken since our migration to Go modules.

Basically, we use `/app` as work dir to ensure that Go is in module mode and `-mod=vendor` to ensure that the vendor directory is used and trusted for locating dependencies.