### PR TITLE
download-golangci-lint.sh: Use hardcoded checksums

### DIFF
--- a/scripts/checksums/golangci-lint-checksums.txt
+++ b/scripts/checksums/golangci-lint-checksums.txt
@@ -1,0 +1,6 @@
+da6f2a181cc0de7744c1e009fb3802dda537105078dd25103beef79b28a36630  golangci-lint-1.15.0-linux-386.tar.gz
+3b48ec9b122defc8e54eff77e8268dec9620ea9f6c60eaa4113585473a40a9c8  golangci-lint-1.15.0-darwin-386.tar.gz
+083941efa692bfe3c29ba709964e9fe5896889316d51813e523157c96c3153e0  golangci-lint-1.15.0-darwin-amd64.tar.gz
+0a143e22e248fba1ed04338cbd3605444eee18ca6da7a433d8ef44ad60a2db9a  golangci-lint-1.15.0-windows-386.zip
+f37f4a15eb309578b0546703da5ea96bc5bd472f45f204338051aaca6fbbfc5b  golangci-lint-1.15.0-linux-amd64.tar.gz
+f047e2dc7ee3b88600c316f4445edf1fb89107449eeec61e96be79a8d84117a8  golangci-lint-1.15.0-windows-amd64.zip

--- a/scripts/download-golangci-lint.sh
+++ b/scripts/download-golangci-lint.sh
@@ -23,7 +23,6 @@ uname_arch() {
   echo ${arch}
 }
 
-CHECKSUMS="checksums.txt"
 TARGET="golangci-lint.tar.gz"
 VERSION=1.15.0
 OS=$(uname_os)
@@ -31,25 +30,24 @@ ARCH=$(uname_arch)
 PLATFORM="${OS}/${ARCH}"
 
 tmpdir=$(mktemp -d)
-pushd $tmpdir
 
 is_command() {
   command -v "$1" >/dev/null
 }
 
 hash_sha256() {
-  TARGET=${1}
+  target_abs=${tmpdir}/${TARGET}
   if is_command gsha256sum; then
-    hash=$(gsha256sum "$TARGET") || return 1
+    hash=$(gsha256sum "$target_abs") || return 1
     echo "$hash" | cut -d ' ' -f 1
   elif is_command sha256sum; then
-    hash=$(sha256sum "$TARGET") || return 1
+    hash=$(sha256sum "$target_abs") || return 1
     echo "$hash" | cut -d ' ' -f 1
   elif is_command shasum; then
-    hash=$(shasum -a 256 "$TARGET" 2>/dev/null) || return 1
+    hash=$(shasum -a 256 "$target_abs" 2>/dev/null) || return 1
     echo "$hash" | cut -d ' ' -f 1
   elif is_command openssl; then
-    hash=$(openssl -dst openssl dgst -sha256 "$TARGET") || return 1
+    hash=$(openssl -dst openssl dgst -sha256 "$target_abs") || return 1
     echo "$hash" | cut -d ' ' -f a
   else
     log_crit "hash_sha256 unable to find command to compute sha-256 hash"
@@ -57,17 +55,23 @@ hash_sha256() {
   fi
 }
 
-curl -fL https://github.com/golangci/golangci-lint/releases/download/v${VERSION}/golangci-lint-${VERSION}-checksums.txt -o ${CHECKSUMS}
-curl -fL https://github.com/golangci/golangci-lint/releases/download/v${VERSION}/golangci-lint-${VERSION}-${OS}-${ARCH}.tar.gz -o $TARGET
-WANT=$(grep golangci-lint-${VERSION}-${OS}-${ARCH}.tar.gz ${CHECKSUMS}|cut -d ' ' -f1)
-GOT=$(hash_sha256 ${TARGET})
-if [ "$WANT" != "$GOT" ]; then
-  log_err "Couldn't verify SHA256 checksum for '$TARGET'"
-  exit 1
-fi
+verify_hash() {
+  checksums="scripts/checksums/golangci-lint-checksums.txt"
+  WANT=$(grep golangci-lint-${VERSION}-${OS}-${ARCH}.tar.gz ${checksums} |cut -d ' ' -f1)
+  GOT=$(hash_sha256)
+  if [ "$WANT" != "$GOT" ]; then
+    log_err "Couldn't verify SHA256 checksum for '$TARGET'"
+    exit 1
+  fi
+}
 
-tar x -C $(go env GOPATH|cut -f1 -d:)/bin --strip-components=1 -f ${TARGET} \
+curl -fL https://github.com/golangci/golangci-lint/releases/download/v${VERSION}/golangci-lint-${VERSION}-${OS}-${ARCH}.tar.gz -o ${tmpdir}/$TARGET
+verify_hash
+
+dest_dir=$(go env GOPATH|cut -f1 -d:)/bin
+tar x -C ${dest_dir} --strip-components=1 -f ${tmpdir}/${TARGET} \
 golangci-lint-${VERSION}-${OS}-${ARCH}/golangci-lint
 
-popd
 rm -rf $tmpdir
+
+echo "* Successfully installed golangci-lint to ${dest_dir}"


### PR DESCRIPTION
Use hardcoded checksums in scripts/download-golangci-lint.sh, for improved security.