### PR TITLE
Remove superfluous require.Nil from test

### DIFF
--- a/gossip3/tupelo_integration_test.go
+++ b/gossip3/tupelo_integration_test.go
@@ -218,7 +218,6 @@ func TestLibP2PSigning(t *testing.T) {
 	require.Nil(t, err)
 
 	fut := client.Subscribe(string(trans.ObjectID), newTip, 90*time.Second)
-	require.Nil(t, err)
 
 	client.SendTransaction(&trans)
 	start := time.Now()


### PR DESCRIPTION
Remove left over `require.Nil(t, err)` from test.