### PR TITLE
Download deps before linting, to avoid lint timeout

### DIFF
--- a/scripts/build-within-docker.sh
+++ b/scripts/build-within-docker.sh
@@ -9,6 +9,7 @@ if [[ "${CI}" == "true" ]]; then
   sudo ./scripts/download-protoc.sh
 fi
 
+go mod download
 make lint
 if [[ "${CI}" == "true" ]]; then
   make ci-test


### PR DESCRIPTION
Linting times out sometimes during CI - download dependencies before linting, to make the linting step speedier.