### PR TITLE
Upgrade Dockerfile to use Go 1.12, Alpine for both stages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,15 @@
-FROM golang:1.11.5 AS build
+FROM golang:1.12.4-alpine3.9 AS build
 
 WORKDIR /app
 
+RUN apk add --no-cache --update build-base
+
 COPY . .
 
-RUN go install -mod=vendor -v -a -ldflags '-extldflags "-static"' -gcflags=-trimpath=$GOPATH -asmflags=-trimpath=$GOPATH
+RUN go install -mod=vendor -v -a -ldflags '-extldflags "-static"' -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}"
 
 FROM alpine:3.9
 LABEL maintainer="dev@quorumcontrol.com"
-
-RUN mkdir -p /var/lib/tupelo
-
-WORKDIR /var/lib/tupelo
 
 COPY --from=build /go/bin/tupelo /usr/bin/tupelo
 


### PR DESCRIPTION
Upgrade Dockerfile to use Go 1.12.4 (since docker-compose won't work otherwise) and Alpine Linux for both stages, for consistency and because I know that if we switch from static to dynamic build the build stage has to be Alpine too. In my feature/kubernetes branch I switch to dynamic build, in order to make it work under k8s.