### PR TITLE
Handle IPFS plugin errors

### DIFF
--- a/ipfs/plugins.go
+++ b/ipfs/plugins.go
@@ -1,0 +1,33 @@
+package ipfs
+
+import (
+	"fmt"
+
+	"github.com/ipfs/go-ipfs/plugin/loader"
+)
+
+var pluginsInjected bool
+
+// InjectPlugins injects IPFS plugins.
+//
+// If IPFS plugins are already injected, this function does nothing.
+func InjectPlugins() error {
+	if pluginsInjected {
+		return nil
+	}
+
+	plugins, err := loader.NewPluginLoader("")
+	if err != nil {
+		return fmt.Errorf("could not initialize IPFS plugin loader: %s", err)
+	}
+	if err = plugins.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize IPFS plugins: %s", err)
+	}
+	if err = plugins.Inject(); err != nil {
+		return fmt.Errorf("failed to inject IPFS plugins: %s", err)
+	}
+
+	pluginsInjected = true
+
+	return nil
+}

--- a/wallet/adapters/ipld.go
+++ b/wallet/adapters/ipld.go
@@ -7,10 +7,10 @@ import (
 	ipfsHttpClient "github.com/ipfs/go-ipfs-http-client"
 	"github.com/ipfs/go-ipfs/core"
 	"github.com/ipfs/go-ipfs/core/coreapi"
-	"github.com/ipfs/go-ipfs/plugin/loader"
 	"github.com/ipfs/go-ipfs/repo/fsrepo"
 	ma "github.com/multiformats/go-multiaddr"
 	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/tupelo/ipfs"
 )
 
 const IpldStorageAdapterName = "ipld"
@@ -75,15 +75,8 @@ func NewIpldNodeStorage(config map[string]interface{}) (*IpldStorageAdapter, err
 		return nil, fmt.Errorf("IPFS daemon has lock on %v, please stop it before running tupelo", repoRoot)
 	}
 
-	plugins, err := loader.NewPluginLoader("")
-	if err != nil {
-		return nil, fmt.Errorf("Could not initialize ipfs plugin loader")
-	}
-	if err = plugins.Initialize(); err != nil {
-		return nil, fmt.Errorf("failed to initialize ipfs plugins: %s", err)
-	}
-	if err = plugins.Inject(); err != nil {
-		return nil, fmt.Errorf("failed to inject ipfs plugins: %s", err)
+	if err = ipfs.InjectPlugins(); err != nil {
+		return nil, err
 	}
 
 	repo, err := fsrepo.Open(repoRoot)

--- a/wallet/wallet_test.go
+++ b/wallet/wallet_test.go
@@ -15,7 +15,6 @@ import (
 	ipfsCore "github.com/ipfs/go-ipfs/core"
 	ipfsCoreHttp "github.com/ipfs/go-ipfs/core/corehttp"
 	ipfsMock "github.com/ipfs/go-ipfs/core/mock"
-	ipfsPluginLoader "github.com/ipfs/go-ipfs/plugin/loader"
 	ipfsFsRepo "github.com/ipfs/go-ipfs/repo/fsrepo"
 	cbornode "github.com/ipfs/go-ipld-cbor"
 	ma "github.com/multiformats/go-multiaddr"
@@ -28,6 +27,7 @@ import (
 
 	"github.com/quorumcontrol/tupelo-go-client/consensus"
 	extmsgs "github.com/quorumcontrol/tupelo-go-client/gossip3/messages"
+	"github.com/quorumcontrol/tupelo/ipfs"
 	"github.com/quorumcontrol/tupelo/wallet/adapters"
 )
 
@@ -109,11 +109,7 @@ func TestIpldWallet(t *testing.T) {
 		},
 	}
 
-	plugins, err := ipfsPluginLoader.NewPluginLoader("")
-	require.Nil(t, err)
-	err = plugins.Initialize()
-	require.Nil(t, err)
-	err = plugins.Inject()
+	err = ipfs.InjectPlugins()
 	require.Nil(t, err)
 
 	conf, err := ipfsConfig.Init(os.Stdout, 2048)


### PR DESCRIPTION
Don't ignore IPFS plugin sub-system errors. Make wallet tests and implementation code use a function that ensures IPFS plugins are only injected once, in order to avoid error arising from injecting plugins both in tests and in implementation code.