### PR TITLE
Don't copy chaintree from nodestore to memstore in every wallet call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/quorumcontrol/chaintree v0.0.0-20190426130059-9145fcfcdb66e952d8c7da1fc27d23169710c8d3
 	github.com/quorumcontrol/storage v1.1.2
-	github.com/quorumcontrol/tupelo-go-client v0.2.0
+	github.com/quorumcontrol/tupelo-go-client v0.2.1-0.20190429222405-79e4695834aa
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -667,6 +667,8 @@ github.com/quorumcontrol/tupelo-go-client v0.1.2-0.20190419170055-17afb89fe62f55
 github.com/quorumcontrol/tupelo-go-client v0.1.2-0.20190419170055-17afb89fe62f559ec7a15b2283c0345f6080685d/go.mod h1:uclhABtqlprocMWgqfuPayqFZO58b+QYGxc1TXMCjPM=
 github.com/quorumcontrol/tupelo-go-client v0.2.0 h1:LhmnWrbFEFzjbGOgNjry5IfDTtklMMCe7y1ieOG5bWo=
 github.com/quorumcontrol/tupelo-go-client v0.2.0/go.mod h1:uclhABtqlprocMWgqfuPayqFZO58b+QYGxc1TXMCjPM=
+github.com/quorumcontrol/tupelo-go-client v0.2.1-0.20190429222405-79e4695834aa h1:7b+IvWUXRKkPwcitpyYZUU9KNIv1xbcxNxjJUIKY744=
+github.com/quorumcontrol/tupelo-go-client v0.2.1-0.20190429222405-79e4695834aa/go.mod h1:uclhABtqlprocMWgqfuPayqFZO58b+QYGxc1TXMCjPM=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/wallet/file.go
+++ b/wallet/file.go
@@ -122,6 +122,10 @@ func (fw *FileWallet) SaveChain(signedChain *consensus.SignedChainTree) error {
 	return fw.wallet.SaveChain(signedChain)
 }
 
+func (fw *FileWallet) SaveChainMetadata(signedChain *consensus.SignedChainTree) error {
+	return fw.wallet.SaveChainMetadata(signedChain)
+}
+
 func (fw *FileWallet) GetChainIds() ([]string, error) {
 	return fw.wallet.GetChainIds()
 }

--- a/wallet/walletrpc/session.go
+++ b/wallet/walletrpc/session.go
@@ -454,7 +454,7 @@ func (rpcs *RPCSession) PlayTransactions(chainId, keyAddr string, transactions [
 		return nil, err
 	}
 
-	err = rpcs.wallet.SaveChain(chain)
+	err = rpcs.wallet.SaveChainMetadata(chain)
 	if err != nil {
 		return nil, fmt.Errorf("error saving chain: %v", err)
 	}


### PR DESCRIPTION
With https://github.com/quorumcontrol/tupelo-go-client/pull/51 , its now unnecessary to copy nodes here to an ephemeral memory store. This splits out the storage of signature & tip metadata as `SaveChainMetadata` to use with `PlayTransactions`, and then also calls that method within `SaveChain` for backward compatibility. 