### PR TITLE
upgrade to latest go-sdk which has CPU fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/quorumcontrol/chaintree v0.0.0-20190426130059-9145fcfcdb66e952d8c7da1fc27d23169710c8d3
 	github.com/quorumcontrol/storage v1.1.2
-	github.com/quorumcontrol/tupelo-go-sdk v0.2.1-0.20190501192947-deae39695b92
+	github.com/quorumcontrol/tupelo-go-sdk v0.2.1-0.20190501192947-fe26b89becfba2b5fcd7e9d6f856c11ac7b7c7ab
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/spf13/cobra v0.0.3
 	github.com/spf13/viper v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -661,8 +661,8 @@ github.com/quorumcontrol/namedlocker v0.0.0-20180808140020-3f797c8b12b1 h1:FglNF
 github.com/quorumcontrol/namedlocker v0.0.0-20180808140020-3f797c8b12b1/go.mod h1:7JSFW45PpKoXFaUpaJ8YtCNIwQWut0+Huo9ugBnKVe4=
 github.com/quorumcontrol/storage v1.1.2 h1:F6qRGnWx2GzO5fitMh8axvT9NjHUHnGp3n2MYwnjKP4=
 github.com/quorumcontrol/storage v1.1.2/go.mod h1:QGtqgqqMaULflN8Jcctj3zdzMFoyE/RxP0uTd15EKtY=
-github.com/quorumcontrol/tupelo-go-sdk v0.2.1-0.20190501192947-deae39695b92 h1:7YJuvc2KhhLLKjTADTvD5fsyDyjRQtPYz3xSgvYVSgQ=
-github.com/quorumcontrol/tupelo-go-sdk v0.2.1-0.20190501192947-deae39695b92/go.mod h1:Z4iAjDM7bHR/y6b++GxVaWXRCuSZGLABUCBV2OacrG8=
+github.com/quorumcontrol/tupelo-go-sdk v0.2.1-0.20190501192947-fe26b89becfba2b5fcd7e9d6f856c11ac7b7c7ab h1:AZaoa1cELyhJB1RW6gRWmqAN3faotf8a9nq2Wj0aKn8=
+github.com/quorumcontrol/tupelo-go-sdk v0.2.1-0.20190501192947-fe26b89becfba2b5fcd7e9d6f856c11ac7b7c7ab/go.mod h1:Z4iAjDM7bHR/y6b++GxVaWXRCuSZGLABUCBV2OacrG8=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
has this: https://github.com/quorumcontrol/tupelo-go-sdk/pull/53