### PR TITLE
Makefile: Build tupelo executable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ vendor: go.mod go.sum $(FIRSTGOPATH)/bin/modvendor
 	modvendor -copy="**/*.c **/*.h"
 
 tupelo: $(packr) $(generated) $(gosources) go.mod go.sum
-	go build ./...
+	go build
 
 lint: $(FIRSTGOPATH)/bin/golangci-lint
 	$(FIRSTGOPATH)/bin/golangci-lint run --build-tags integration


### PR DESCRIPTION
I realized that we should just use `go build` in order to produce the `tupelo` executable, the `go build ./...` form is for compiling multiple packages and doesn't output anything. With this PR, a `tupelo` executable will be built, which is useful for testing without installing.