### PR TITLE
Remove unused keyAddr arg from list-tokens

### DIFF
--- a/wallet/walletrpc/session.go
+++ b/wallet/walletrpc/session.go
@@ -794,7 +794,7 @@ func (rpcs *RPCSession) GetTokenBalance(chainId, token string) (uint64, error) {
 	return bal, nil
 }
 
-func (rpcs *RPCSession) ListTokens(chainId, keyAddr string) (string, error) {
+func (rpcs *RPCSession) ListTokens(chainId string) (string, error) {
 	tokensPath, err := consensus.DecodePath("tree/_tupelo/tokens")
 	if err != nil {
 		return "", err

--- a/wallet/walletshell/gossipshell.go
+++ b/wallet/walletshell/gossipshell.go
@@ -439,16 +439,16 @@ func RunGossip(name string, storagePath string, notaryGroup *types.NotaryGroup, 
 		},
 	})
 
-	listTokensUsage := "usage: list-tokens chain-id key-id"
+	listTokensUsage := "usage: list-tokens chain-id"
 	shell.AddCmd(&ishell.Cmd{
 		Name: "list-tokens",
 		Help: "lists all tokens and their balances. " + listTokensUsage,
 		Func: func(c *ishell.Context) {
-			if len(c.Args) < 2 {
+			if len(c.Args) < 1 {
 				c.Println("not enough arguments to list-tokens. " + listTokensUsage)
 				return
 			}
-			tokens, err := session.ListTokens(c.Args[0], c.Args[1])
+			tokens, err := session.ListTokens(c.Args[0])
 			if err != nil {
 				c.Printf("error listing tokens: %v\n", err)
 				return


### PR DESCRIPTION
I thought the Go compiler was preventing me from making silly errors like this, but I guess not for function args. I'll have to keep a better eye out for this in the future. :)