### PR TITLE
add connection manager to tupelo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,9 @@ require (
 	github.com/ipfs/go-log v0.0.1
 	github.com/jakehl/goid v1.1.0
 	github.com/karrick/godirwalk v1.10.3 // indirect
+	github.com/libp2p/go-libp2p v0.0.21
+	github.com/libp2p/go-libp2p-circuit v0.0.4
+	github.com/libp2p/go-libp2p-connmgr v0.0.3
 	github.com/libp2p/go-libp2p-peer v0.1.0
 	github.com/libp2p/go-libp2p-pubsub v0.0.3
 	github.com/mitchellh/go-homedir v1.1.0


### PR DESCRIPTION
This is in the "simplest thing to work" section of https://trello.com/c/9JnFNIqD/235-explore-using-a-connection-manager-in-tupelo

it also moves testnode -> node in the cmd directory because I think we're past the point of calling these nodes "test" only :).

Just adds in a simple connection manager. The one for the node will protect the other signers from disconnection.