### PR TITLE
don't panic on bad tip requests

### DIFF
--- a/gossip3/actors/tupelo.go
+++ b/gossip3/actors/tupelo.go
@@ -164,7 +164,8 @@ func (tn *TupeloNode) handleGetTip(context actor.Context, msg *extmsgs.GetTip) {
 	tn.Log.Debugw("handleGetTip", "tip", msg.ObjectID)
 	currStateBits, err := tn.cfg.CurrentStateStore.Get(msg.ObjectID)
 	if err != nil {
-		panic(fmt.Errorf("error getting tip: %v", err))
+		tn.Log.Errorw("error getting tip", "err", err)
+		return
 	}
 
 	var currState extmsgs.CurrentState
@@ -172,7 +173,8 @@ func (tn *TupeloNode) handleGetTip(context actor.Context, msg *extmsgs.GetTip) {
 	if len(currStateBits) > 0 {
 		_, err = currState.UnmarshalMsg(currStateBits)
 		if err != nil {
-			panic(fmt.Errorf("error unmarshaling CurrentState: %v", err))
+			tn.Log.Errorw("error unmarshaling CurrentState", "err", err)
+			return
 		}
 	}
 


### PR DESCRIPTION
this stops panicing on a bad request to getTip. Instead it just logs and then silently ignores