### PR TITLE
remove the broadcasting of bad transactions

### DIFF
--- a/gossip3/actors/conflictset.go
+++ b/gossip3/actors/conflictset.go
@@ -428,10 +428,10 @@ func (csw *ConflictSetWorker) handleCurrentStateWrapper(cs *ConflictSet, context
 		for _, t := range cs.transactions {
 			transSpan := t.NewSpan("handleCurrentStateWrapper")
 			transSpan.SetTag("done", true)
-			transSpan.Finish()
 			if !bytes.Equal(t.Transaction.NewTip, currWrapper.CurrentState.Signature.NewTip) {
-				currWrapper.FailedTransactions = append(currWrapper.FailedTransactions, t)
+				transSpan.SetTag("error", true)
 			}
+			transSpan.Finish()
 		}
 
 		cs.done = true

--- a/gossip3/messages/messages.go
+++ b/gossip3/messages/messages.go
@@ -41,8 +41,6 @@ type CurrentStateWrapper struct {
 	CurrentState *extmsgs.CurrentState
 	Metadata     MetadataMap
 	NextHeight   uint64
-
-	FailedTransactions []*TransactionWrapper
 }
 
 func (csw *CurrentStateWrapper) MustMarshal() []byte {


### PR DESCRIPTION
This stops tupelo from sending errors on transactions. As discussed in https://trello.com/c/fe4bgznx/230-remove-signer-produced-errors-for-transactions these are actually attack vectors because they don't carry proof with them.