### PR TITLE
Set GO111MODULE to on in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ else
 	TAG = $(VERSION)
 endif
 
+# This is important to export until we're on Go 1.13+ or packr can break
+export GO111MODULE = on
+
 MD5CMD = $(shell { command -v md5sum || command -v md5; } 2>/dev/null)
 
 # GUARD is a function which calculates md5 sum for its


### PR DESCRIPTION
This fixes my dreaded periodic issue where packr randomly starts complaining it can't find some module that clearly exists in the source tree. Apparently the packr devs are being... something... about `GO111MODULE=auto` mode (which is what you get by default until Go 1.13 changes it to `on`) and [have decided not to support it](https://gobuffalo.io/en/docs/gomods).

Exporting this in the `Makefile` seems to fix it (after a `make clean` anyway).