### PR TITLE
remove temporary js branch test, and restore master and latest

### DIFF
--- a/.tupelo-integration.yml
+++ b/.tupelo-integration.yml
@@ -4,12 +4,9 @@ tupelos:
     command: ["rpc-server", "-l", "3"]
 
 testers:
-  js-sdk-proto:
-    image: quorumcontrol/tupelo-js-sdk:deserialize-responses
+  js-sdk-latest:
+    image: quorumcontrol/tupelo-js-sdk:latest
     command: ["npx", "mocha", "--exit"]
-  # js-sdk-latest:
-  #   image: quorumcontrol/tupelo-js-sdk:latest
-  #   command: ["npx", "mocha", "--exit"]
-  # js-sdk-master:
-  #   image: quorumcontrol/tupelo-js-sdk:master
-  #   command: ["npx", "mocha", "--exit"]
+  js-sdk-master:
+    image: quorumcontrol/tupelo-js-sdk:master
+    command: ["npx", "mocha", "--exit"]


### PR DESCRIPTION
I disabled the `master` and `latest` js-sdk tests and set a temporary test for the js-sdk proto branch until that branch was merged on the js-sdk side. Well, that branch has been merged, so this patch reverses those changes.