### PR TITLE
Add Kubernetes support

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -148,7 +148,8 @@ var benchmark = &cobra.Command{
 		config := nodebuilderConfig
 		if config == nil {
 			var err error
-			config, err = nodebuilder.LegacyConfig(configNamespace, 0, enableElasticTracing, enableJaegerTracing, overrideKeysFile)
+			config, err = nodebuilder.LegacyConfig(configNamespace, 0, enableElasticTracing,
+				enableJaegerTracing, overrideKeysFile)
 			if err != nil {
 				panic(fmt.Errorf("error generating legacy config: %v", err))
 			}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -30,9 +30,12 @@ var bootstrapNodeCmd = &cobra.Command{
 
 		nb := &nodebuilder.NodeBuilder{Config: c}
 
-		err := nb.Start(ctx)
-		if err != nil {
+		if err := nb.Start(ctx); err != nil {
 			panic(fmt.Errorf("error starting bootstrap: %v", err))
+		}
+
+		if err := startPromServer(); err != nil {
+			panic(err)
 		}
 
 		fmt.Println("Bootstrap node running at:")

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -46,21 +46,25 @@ var testnodeCmd = &cobra.Command{
 		config := nodebuilderConfig
 		if config == nil {
 			var err error
-			config, err = nodebuilder.LegacyConfig(configNamespace, testnodePort, enableElasticTracing, enableJaegerTracing, overrideKeysFile)
+			config, err = nodebuilder.LegacyConfig(configNamespace, testnodePort, enableElasticTracing,
+				enableJaegerTracing, overrideKeysFile)
 			if err != nil {
 				panic(fmt.Errorf("error getting legacy config: %v", err))
 			}
 		}
 
 		nb := &nodebuilder.NodeBuilder{Config: config}
-		err := nb.Start(ctx)
-		if err != nil {
+		if err := nb.Start(ctx); err != nil {
 			panic(fmt.Errorf("error starting: %v", err))
 		}
-		err = nb.Host().WaitForBootstrap(len(config.NotaryGroupConfig.Signers)/2, 30*time.Second)
-		if err != nil {
+		if err := nb.Host().WaitForBootstrap(len(config.NotaryGroupConfig.Signers)/2, 30*time.Second); err != nil {
 			panic(fmt.Errorf("error starting: %v", err))
 		}
+
+		if err := startPromServer(); err != nil {
+			panic(err)
+		}
+
 		fmt.Printf("started signer host %s on %v\n", nb.Host().Identity(), nb.Host().Addresses())
 		select {}
 	},

--- a/cmd/prometheus.go
+++ b/cmd/prometheus.go
@@ -1,0 +1,19 @@
+package cmd
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/middleware"
+)
+
+// startPromServer starts an HTTP server providing Prometheus metrics
+func startPromServer() error {
+	http.Handle("/metrics", promhttp.Handler())
+	go func() {
+		if err := http.ListenAndServe(":2112", nil); err != nil {
+			middleware.Log.Errorw("Prometheus metrics server failed", "error", err)
+		}
+	}()
+	return nil
+}

--- a/cmd/rpcserver.go
+++ b/cmd/rpcserver.go
@@ -84,7 +84,8 @@ var rpcServerCmd = &cobra.Command{
 
 			config := nodebuilderConfig
 			if config == nil {
-				config, err = nodebuilder.LegacyConfig(configNamespace, 0, enableElasticTracing, enableJaegerTracing, overrideKeysFile)
+				config, err = nodebuilder.LegacyConfig(configNamespace, 0, enableElasticTracing,
+					enableJaegerTracing, overrideKeysFile)
 				if err != nil {
 					panic(fmt.Errorf("error generating legacy config: %v", err))
 				}

--- a/cmd/shell.go
+++ b/cmd/shell.go
@@ -49,7 +49,8 @@ var shellCmd = &cobra.Command{
 
 			config := nodebuilderConfig
 			if config == nil {
-				config, err = nodebuilder.LegacyConfig(configNamespace, 0, enableElasticTracing, enableJaegerTracing, overrideKeysFile)
+				config, err = nodebuilder.LegacyConfig(configNamespace, 0, enableElasticTracing,
+					enableJaegerTracing, overrideKeysFile)
 				if err != nil {
 					panic(fmt.Errorf("error generating legacy config: %v", err))
 				}

--- a/docs/manual.md
+++ b/docs/manual.md
@@ -1,0 +1,136 @@
+# Tupelo Technical Manual
+This is the technical manual for the Tupelo distributed ledger technology (DLT for short).
+
+## About Tupelo
+Tupelo is a peer to peer system, based around the "chain tree" concept. Each chain tree is
+a directed acyclic graph (DAG) of state, which gets produced through a sequence of transaction
+blocks, each of which gets agreed upon by a group of signer nodes. Since individual transactions
+get accepted through network concensus, the current state of a tree (i.e. the "tip") is
+also commonly agreed upon.
+
+Peers that wish to join the network connect via so-called bootstrap nodes. After bootstrapping,
+they can submit transactions for signing by signer nodes, by publishing messages through libp2p
+pubsub.
+
+## Client Usage
+A Tupelo client that wishes to work with a chain tree, will first bootstrap with the network
+by calling `p2p.LibP2PHost.Bootstrap` supplying the addresses of the bootstrap nodes.
+
+Then it will set up a notary group, using the public keys of the signer nodes. By calling
+`gossip3/types.NotaryGroup.SetupAllRemoteActors`, each of the signer objects will also have
+a remote actor representation in order to interact with the corresponding remote signer.
+
+### Adding Chain Tree Transactions
+In order for a client to update a chain tree by sending one or more transactions, it must first
+of all have a copy of it. A Go implementation might for example have a 
+[Badger](https://github.com/dgraph-io/badger) database based storage adapter, where it keeps
+a serialized representation of the chain tree between sessions.
+
+Before constructing transactions, the client will deserialize a chain tree representation from
+the representation in storage. Then one or more transactions, e.g. to set a data property, will be
+constructed given the tip of the chain tree. The transaction block will afterwards be broadcasted
+for signing off by signer nodes.
+
+## Signer Behaviour
+Signer nodes listen for messages on a libp2p pubsub system, that are for a certain topic.
+Once nodes receive such messages, they are passed on to the Tupelo actor which processes
+them according to their type. The different types of messages are discussed beneath:
+
+### AddBlockRequest
+`AddBlockRequest` messages are sent by clients in order to execute a set of transactions, 
+which Tupelo encapsulates as a so-called block. Once a signer receives a message of this type,
+it will schedule a validation of the block. A validator actor proceeds to validate the block
+and if it can find the corresponding chain tree in its storage, it will check if the
+block is for the expected transaction height; otherwise, if it's higher than expected,
+it will be marked as preflight, if it's lower than expected, it will be marked as stale. If
+the corresponding chain tree isn't found in storage, the block is marked as preflight.
+
+If a block passes all the aforementioned checks and is thus validated, it gets marked as accepted
+and the Tupelo actor receives a `TransactionWrapper` message wrapping the `AddBlockRequest`.
+
+### TransactionWrapper
+The Tupelo actor receives `TransactionWrapper` messages from validator actors, in response
+to requests to validate `AddBlockRequest` messages. The Tupelo actor sends them on to
+the conflict set router actor. Said actor first checks if a conflict set should be created for the 
+message or not, identified by corresponding chain tree and height. If not (i.e., it's already been 
+processed), the actor simply ignores the message, otherwise it creates a conflict set
+representation and requests that one of its workers process it.
+
+A worker processes a conflict set by obtaining a signature, then checking if the conflict set
+has enough signatures (>= quorum count). If it does, a `CurrentStateWrapper` message representing
+the updated current state is created and sent to the conflict set router. The latter
+proceeds to broadcast the message to the network (so other signers can sync), and also
+prunes conflict sets for the same chain tree and with heights lower than or equal to the 
+current one.
+
+### ValidateTransaction
+The Tupelo actor receives `ValidateTransaction` messages from conflict set workers, when
+snoozed transactions need to be validated as part of conflict set activation. This is in turn
+triggered by the Tupelo actor sending `ActivateSnoozingConflictSets` to the conflict set
+router when a `CurrentStateWrapper` message is received, i.e. a new current state has been
+committed.
+
+The Tupelo actor responds to this message by sending a corresponding `validationRequest` message
+to the validator pool.
+
+### CurrentStateWrapper
+When the Tupelo actor receives a `CurrentStateWrapper` message, it first of all stores the
+updated current state for the chain tree ID. Then it sends an `ActivateSnoozingConflictSets`
+message to the conflict set router, in order to activate snoozed conflict sets.
+
+The reason for activating snoozed conflict sets here is that when a new chain tree state
+is reached, we will want to re-process conflict sets with snoozed (previously) pre-flight
+transactions or with a snoozed current state commit.
+
+If a conflict set in this situation has a snoozed current state commit, it gets processed
+and if the commit is of the correct height the conflict set is activated and marked as done.
+
+Otherwise, if the conflict set is _not_ considered done, any transactions it has are 
+re-validated, by sending corresponding `ValidateTransaction` messages to the conflict set router,
+which forwards it to the Tupelo actor.
+
+If the `CurrentStateWrapper` message emanated from within the node, the updated state is
+broadcasted via pubsub in order to notify other signers. 
+
+### Signature
+`Signature` messages get forwarded by the Tupelo actor to the conflict set router, which
+determines the corresponding conflict set and forwards the message to a corresponding worker
+if the conflict set isn't already done.
+
+If the signature emanates from within the node, the conflict set worker will forward it to other
+signers. Then, the worker will record the new signature for the transaction in question
+and increment the conflict set's number of updates. Finally, the worker will send a
+`checkStateMsg` to itself, to trigger a state check.
+
+Upon receipt of a `checkStateMsg`, a conflict set worker will first of all check if the message's
+update counter is at least as high as that of the conflict set. If it isn't, it's considered
+stale and simply ignored. Then the worker goes on to check if the conflict set is done;
+if it has a transaction block with enough signatures (>= quorum count), it's considered done and
+a new current state is committed from the transaction block in question. A corresponding 
+`CurrentStateWrapper` message is sent to the conflict set router in order to propagate the
+state change.
+
+### GetTipRequest
+TODO
+
+### RequestCurrentStateSnapshot
+TODO
+
+## Monitoring
+Tupelo supports monitoring with Prometheus. In order to accomplish this it uses the standard
+Prometheus [client library](https://github.com/prometheus/client_golang) to expose
+metrics via an HTTP server, and also to produce custom metrics.
+
+### Metrics
+Tupelo produces the following Prometheus metrics:
+
+#### Total Number of Transactions
+A counter of total number of transactions handled.
+
+#### Current Number of Chain Trees
+A gauge of current number of chain trees. A chain tree is created by issuing a genesis
+transaction. When a signer node receives such a transaction, it increases the aforementioned
+gauge.
+
+#### Number of Currently Snoozed Conflict Sets
+A gauge of current number of snoozed conflict sets.

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/libp2p/go-libp2p-core v0.0.6
 	github.com/libp2p/go-libp2p-pubsub v0.1.0
 	github.com/opentracing/opentracing-go v1.1.0
-	github.com/prometheus/common v0.6.0 // indirect
+	github.com/prometheus/client_golang v0.9.3
 	github.com/quorumcontrol/chaintree v0.0.0-20190701175144-f8f44c3e6d4b
 	github.com/quorumcontrol/messages/build/go v0.0.0-20190723140659-c8a3565a7c72
 	github.com/quorumcontrol/tupelo-go-sdk v0.5.3-rc1
@@ -41,11 +41,9 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.3.0
 	go.dedis.ch/protobuf v1.0.6 // indirect
-	go.opencensus.io v0.22.0 // indirect
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20190621222207-cc06ce4a13d4
 	golang.org/x/net v0.0.0-20190620200207-3b0461eec859
-	google.golang.org/genproto v0.0.0-20190611190212-a7e196e89fd3 // indirect
 	google.golang.org/grpc v1.21.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -482,6 +482,7 @@ github.com/polydawn/refmt v0.0.0-20190408063855-01bf1e26dd14 h1:2m16U/rLwVaRdz7A
 github.com/polydawn/refmt v0.0.0-20190408063855-01bf1e26dd14/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
+github.com/prometheus/client_golang v0.9.3 h1:9iH4JKXLzFbOAdtqv/a+j8aewx2Y8lAjAydhbaScPF8=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
@@ -489,6 +490,7 @@ github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.0 h1:7etb9YClo3a6HjLzfl6rIQaU+FDfi0VSX39io3aQ+DM=
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0 h1:kRhiuYSXR3+uv2IbVbZhUxK5zVD/2pp3Gd2PpvPkpEo=
@@ -496,6 +498,7 @@ github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0 h1:c8R11WC8m7KNMkTv/0+Be8vvwo4I3/Ut9AC2FW8fX3U=
 github.com/prometheus/procfs v0.0.0-20190425082905-87a4384529e0/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
+github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084 h1:sofwID9zm4tzrgykg80hfFph1mryUeLRsUfoocVVmRY=
 github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
@@ -608,6 +611,7 @@ go.elastic.co/apm/module/apmot v1.3.0 h1:IEkzPiGFf5oSbQhIHpRGX2Fsh0w/Ye0AcxDr9pK
 go.elastic.co/apm/module/apmot v1.3.0/go.mod h1:w/NpB+GbGidYY4+IpStXcfMybgnaGuluNeiakGI7/OI=
 go.elastic.co/fastjson v1.0.0 h1:ooXV/ABvf+tBul26jcVViPT3sBir0PvXgibYB1IQQzg=
 go.elastic.co/fastjson v1.0.0/go.mod h1:PmeUOMMtLHQr9ZS9J9owrAVg0FkaZDRZJEFTTGHtchs=
+go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.opencensus.io v0.22.0 h1:C9hSCOW830chIVkdja34wa6Ky+IzWllkUinR+BtRZd4=
 go.opencensus.io v0.22.0/go.mod h1:+kGneAE2xo2IficOXnaByMWTGM9T73dGwxeWcUqIpI8=

--- a/gossip3/actors/conflictsetrouter.go
+++ b/gossip3/actors/conflictsetrouter.go
@@ -23,6 +23,7 @@ import (
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/remote"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/types"
 	"github.com/quorumcontrol/tupelo/gossip3/messages"
+	"github.com/quorumcontrol/tupelo/metrics"
 	"go.uber.org/zap"
 )
 
@@ -213,6 +214,7 @@ func (csr *ConflictSetRouter) cleanupConflictSets(msg *messages.CurrentStateWrap
 	})
 	csr.conflictSets = txn.Commit()
 
+	metrics.SetNumConflictSets(int64(csr.conflictSets.Len()))
 	csr.Log.Debugw("finished cleaning up conflict sets", "numRemaining", csr.conflictSets.Len())
 }
 
@@ -280,6 +282,7 @@ func (csr *ConflictSetRouter) getOrCreateCS(objectId []byte, height uint64) *Con
 	sp.SetTag("signer", cfg.Signer.ID)
 	sets, _, _ := csr.conflictSets.Insert(nodeID, cs)
 	csr.conflictSets = sets
+	metrics.SetNumConflictSets(int64(csr.conflictSets.Len()))
 	return cs
 }
 

--- a/gossip3/actors/tupelo.go
+++ b/gossip3/actors/tupelo.go
@@ -16,6 +16,7 @@ import (
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/remote"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/types"
 	"github.com/quorumcontrol/tupelo/gossip3/messages"
+	"github.com/quorumcontrol/tupelo/metrics"
 )
 
 // TupeloNode is the main logic of the entire system,
@@ -83,6 +84,14 @@ func (tn *TupeloNode) handleNewCurrentStateWrapper(context actor.Context, msg *m
 		tn.Log.Debugw("tupelo node sending activatesnoozingconflictsets", "ObjectId", msg.CurrentState.Signature.ObjectId)
 		// un-snooze waiting conflict sets
 		context.Send(tn.conflictSetRouter, &messages.ActivateSnoozingConflictSets{ObjectId: msg.CurrentState.Signature.ObjectId})
+
+		metrics.IncTotalCommittedTransactions()
+		if msg.CurrentState.Signature.Height == 0 {
+			tn.Log.Debugw("increasing the current number of chain trees")
+			metrics.IncNumChainTrees()
+		} else {
+			tn.Log.Debugw("not increasing the current number of chain trees")
+		}
 
 		// if we are the ones creating this current state then broadcast
 		if msg.Internal {

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -1,0 +1,119 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/middleware"
+)
+
+var preflightGauge prometheus.Gauge
+var staleTxnsCounter prometheus.Counter
+var inactiveConflictSetsGauge prometheus.Gauge
+var numConflictSetsGauge prometheus.Gauge
+var committedTransactionsCounter prometheus.Counter
+var chainTreesGauge prometheus.Gauge
+
+func init() {
+	preflightGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "quorumcontrol",
+		Subsystem: "tupelo",
+		Name:      "txns_preflight",
+		Help:      "Number of transactions in preflight.",
+	})
+	if err := prometheus.Register(preflightGauge); err != nil {
+		middleware.Log.Errorw("failed to register preflight gauge")
+	}
+
+	staleTxnsCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "quorumcontrol",
+		Subsystem: "tupelo",
+		Name:      "txns_stale",
+		Help:      "Number of stale transactions received.",
+	})
+	if err := prometheus.Register(staleTxnsCounter); err != nil {
+		middleware.Log.Errorw("failed to register stale transactions counter")
+	}
+
+	inactiveConflictSetsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "quorumcontrol",
+		Subsystem: "tupelo",
+		Name:      "inactive_conflictsets",
+		Help:      "Number of inactive conflict sets.",
+	})
+	if err := prometheus.Register(inactiveConflictSetsGauge); err != nil {
+		middleware.Log.Errorw("failed to register inactive conflict sets gauge")
+	}
+
+	numConflictSetsGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "quorumcontrol",
+		Subsystem: "tupelo",
+		Name:      "num_conflictsets",
+		Help:      "Current number of conflict sets.",
+	})
+	if err := prometheus.Register(numConflictSetsGauge); err != nil {
+		middleware.Log.Errorw("failed to register number of conflict sets gauge")
+	}
+
+	committedTransactionsCounter = prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "quorumcontrol",
+		Subsystem: "tupelo",
+		Name:      "total_committed_transactions",
+		Help:      "Total number of committed transactions.",
+	})
+	if err := prometheus.Register(committedTransactionsCounter); err != nil {
+		middleware.Log.Errorw("failed to register committed transactions counter")
+	}
+
+	chainTreesGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "quorumcontrol",
+		Subsystem: "tupelo",
+		Name:      "total_chain_trees",
+		Help:      "Total number of chain trees.",
+	})
+	if err := prometheus.Register(chainTreesGauge); err != nil {
+		middleware.Log.Errorw("failed to register total number of chain trees gauge")
+	}
+}
+
+// IncPreflightTxns increases the gauge of preflight transactions.
+func IncPreflightTxns() {
+	preflightGauge.Inc()
+}
+
+// DecPreflightTxns decreases the gauge of preflight transactions.
+func DecPreflightTxns() {
+	preflightGauge.Dec()
+}
+
+// IncStaleTxns increases the count of stale transactions received.
+func IncStaleTxns() {
+	staleTxnsCounter.Inc()
+}
+
+// IncInactiveConflictSets increases the gauge of inactive conflict sets.
+func IncInactiveConflictSets() {
+	inactiveConflictSetsGauge.Inc()
+}
+
+// DecInactiveConflictSets decreases the gauge of inactive conflict sets.
+func DecInactiveConflictSets() {
+	inactiveConflictSetsGauge.Dec()
+}
+
+func SetNumConflictSets(num int64) {
+	numConflictSetsGauge.Set(float64(num))
+}
+
+// IncTotalCommittedTransactions increases the counter of committed transactions.
+func IncTotalCommittedTransactions() {
+	committedTransactionsCounter.Inc()
+}
+
+// IncNumChainTrees increases the gauge of total number of chain trees.
+func IncNumChainTrees() {
+	chainTreesGauge.Inc()
+}
+
+// DecNumChainTrees decreases the gauge of total number of chain trees.
+func DecNumChainTrees() {
+	chainTreesGauge.Dec()
+}

--- a/nodebuilder/humanconfig.go
+++ b/nodebuilder/humanconfig.go
@@ -19,10 +19,18 @@ type HumanPrivateKeySet struct {
 }
 
 func (hpks *HumanPrivateKeySet) ToPrivateKeySet() (*PrivateKeySet, error) {
-	signKeyBytes, err := hexutil.Decode(hpks.SignKeyHex)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding sign key: %v", err)
+	var signKey *bls.SignKey
+	if len(hpks.SignKeyHex) > 0 {
+		signKeyBytes, err := hexutil.Decode(hpks.SignKeyHex)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding sign key: %v", err)
+		}
+		signKey = bls.BytesToSignKey(signKeyBytes)
+		if signKey == nil {
+			return nil, fmt.Errorf("couldn't unmarshal sign key")
+		}
 	}
+
 	destKeyBytes, err := hexutil.Decode(hpks.DestKeyHex)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding dest key: %v", err)
@@ -31,7 +39,7 @@ func (hpks *HumanPrivateKeySet) ToPrivateKeySet() (*PrivateKeySet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("couldn't unmarshal ECDSA private key: %v", err)
 	}
-	signKey := bls.BytesToSignKey(signKeyBytes)
+
 	return &PrivateKeySet{
 		SignKey: signKey,
 		DestKey: ecdsaPrivate,
@@ -39,7 +47,7 @@ func (hpks *HumanPrivateKeySet) ToPrivateKeySet() (*PrivateKeySet, error) {
 }
 
 // HumanConfig is used for parsing an ondisk configuration into the application-used Config
-// struct. At the time of this comment, it also uses the types.HumanConfig for notary groups
+// struct. At the time of this comment, it uses the types.HumanConfig for notary groups
 // defined in the tupelo-go-sdk as well.
 type HumanConfig struct {
 	Namespace string

--- a/nodebuilder/legacy.go
+++ b/nodebuilder/legacy.go
@@ -126,7 +126,6 @@ func LegacyConfig(namespace string, port int, enableElasticTracing, enableJaeger
 	if err != nil {
 		return nil, fmt.Errorf("error getting bootstrap keys: %v", err)
 	}
-
 	signers := make([]types.PublicKeySet, len(legacyKeys))
 
 	for i, legacy := range legacyKeys {


### PR DESCRIPTION
Modify Tupelo to support reading configuration from /etc/tupelo/conf.json (in order to support Kubernetes), as well as adding more debug logs.

Please review [the corresponding PR](https://github.com/quorumcontrol/tupelo-go-sdk/pull/79) for the SDK first.