### PR TITLE
no need to dump in the passed in strings anymore

### DIFF
--- a/wallet/walletshell/gossipshell.go
+++ b/wallet/walletshell/gossipshell.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/abiosoft/ishell"
 	"github.com/ethereum/go-ethereum/crypto"
-	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/quorumcontrol/chaintree/chaintree"
 	"github.com/quorumcontrol/messages/build/go/transactions"
 	"github.com/quorumcontrol/tupelo-go-sdk/consensus"
@@ -284,11 +283,7 @@ func RunGossip(name string, storagePath string, notaryGroup *types.NotaryGroup, 
 			keyAddr := c.Args[1]
 
 			path := c.Args[2]
-			data, err := cbornode.DumpObject(c.Args[3])
-			if err != nil {
-				c.Printf("error encoding input: %v\n", err)
-				return
-			}
+			data := c.Args[3]
 
 			txn, err := chaintree.NewSetDataTransaction(path, data)
 			if err != nil {


### PR DESCRIPTION
We encode/decode farther up the stack, so no need to do it here anymore. In fact, when we do it here, we get raw bytes back from resolve!