### PR TITLE
Fix ports of signer nodes

### DIFF
--- a/nodebuilder/legacy.go
+++ b/nodebuilder/legacy.go
@@ -147,6 +147,7 @@ func LegacyConfig(namespace string, port int, enableElasticTracing, enableJaeger
 		PrivateKeySet:     privateKeySet,
 		BootstrapNodes:    p2p.BootstrapNodes(),
 		StoragePath:       configDir(namespace, remoteConfigName),
+		Port:              port,
 	}
 	if enableElasticTracing {
 		c.TracingSystem = ElasticTracing


### PR DESCRIPTION
Fix so that signer nodes port gets set (and not just randomized).

Not sure why `go build` insists on changing go.*, it just does.