### PR TITLE
Remove -mod=readonly rule when building under CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ integration-test: test .tupelo-integration.yml
 
 ci-test: $(packr) $(generated) $(gosources) go.mod go.sum
 	mkdir -p test_results/tests
-	gotestsum --junitfile=test_results/tests/results.xml -- -mod=readonly -tags=integration ./...
+	gotestsum --junitfile=test_results/tests/results.xml -- -tags=integration ./...
 
 ci-integration-test: ci-test integration-test
 


### PR DESCRIPTION
Remove `-mod=readonly` from the `ci-test` Makefile rule, since it turns out to break our CI builds. I tested manually yesterday, and I could see that `go build` needs to modify go.mod when building under CircleCI, whereas it makes no modifications whatsoever on my MacBook. I'm guessing it's due to differences between platforms (Mac and Linux in this case), where Go has to add new dependencies.