### PR TITLE
ConflictSetWorker: Fix checking of whether checkStateMsgs are stale

### DIFF
--- a/gossip3/actors/conflictset.go
+++ b/gossip3/actors/conflictset.go
@@ -299,7 +299,7 @@ func (csw *ConflictSetWorker) checkState(cs *ConflictSet, context actor.Context,
 	defer sp.Finish()
 
 	csw.Log.Debugw("check state")
-	if cs.updates < msg.atUpdate {
+	if msg.atUpdate < cs.updates {
 		csw.Log.Debugw("old update")
 		sp.SetTag("oldUpdate", true)
 		// we know there will be another check state message with a higher update


### PR DESCRIPTION
I don't know if I'm right, since I don't know the logic intimately, but it looks like a bug to me to consider the message as old if it has *more* updates than the conflict set. Please let me know if I got it wrong :)