### PR TITLE
Move error check within scope

### DIFF
--- a/gossip3/actors/conflictset.go
+++ b/gossip3/actors/conflictset.go
@@ -167,12 +167,10 @@ func (csw *ConflictSetWorker) activate(cs *ConflictSet, context actor.Context, m
 
 	cs.active = true
 
-	var err error
 	if cs.snoozedCommit != nil {
-		err = csw.handleCurrentStateWrapper(cs, context, cs.snoozedCommit)
-	}
-	if err != nil {
-		panic(fmt.Errorf("error processing snoozed commit: %v", err))
+		if err := csw.handleCurrentStateWrapper(cs, context, cs.snoozedCommit); err != nil {
+			panic(fmt.Errorf("error processing snoozed commit: %v", err))
+		}
 	}
 
 	if cs.done {


### PR DESCRIPTION
Move error check within scope of enclosing `if` check, in order to increase readability and minimize risk of bugs.