### PR TITLE
use remote network from rpc server and also use real node2 config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,13 +27,13 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
-    command: ["test-node", "--config", "/configs/node1/config.toml"]
+    command: ["test-node", "--config", "/configs/node2/config.toml"]
 
   rpc-server:
     build: .
     volumes:
       - ./configs/localdocker:/configs
-    command: ["rpc-server", "--config", "/configs/rpcserver/config.toml"]
+    command: ["rpc-server","-r", "-l", "0", "--config", "/configs/rpcserver/config.toml"]
     ports:
       - "50051:50051"
 


### PR DESCRIPTION
This fixes a couple of meaculpas here...

1. rpc-server wasn't using the docker network at all (I think I missed some logic back in the adding of configs a while back).
1. fat-fingered the directory node2 was pointing at so we had two node1s operating (and no node 2) - surprised this worked at all :)