### PR TITLE
Fix transactionTopic in configurations for integration tests to work

### DIFF
--- a/configs/localdocker/benchmark/config.toml
+++ b/configs/localdocker/benchmark/config.toml
@@ -16,5 +16,5 @@ DestKeyHex = "0x0468924bd1341b5cec1fed888aaf1e3caa94e7d0f13d4f4573b01b296374b9e7
 
 [NotaryGroup]
 id = "localdocker"
-transactionTopic = "tupelo-pubsub-topics"
+transactionTopic = "tupelo-transaction-broadcast"
 commitTopic = "tupelo-pubsub-commits"

--- a/configs/localdocker/node0/config.toml
+++ b/configs/localdocker/node0/config.toml
@@ -20,5 +20,5 @@ DestKeyHex = "0x0468924bd1341b5cec1fed888aaf1e3caa94e7d0f13d4f4573b01b296374b9e7
 
 [NotaryGroup]
 id = "localdocker"
-transactionTopic = "tupelo-pubsub-topics"
+transactionTopic = "tupelo-transaction-broadcast"
 commitTopic = "tupelo-pubsub-commits"

--- a/configs/localdocker/node1/config.toml
+++ b/configs/localdocker/node1/config.toml
@@ -20,5 +20,5 @@ DestKeyHex = "0x0468924bd1341b5cec1fed888aaf1e3caa94e7d0f13d4f4573b01b296374b9e7
 
 [NotaryGroup]
 id = "localdocker"
-transactionTopic = "tupelo-pubsub-topics"
+transactionTopic = "tupelo-transaction-broadcast"
 commitTopic = "tupelo-pubsub-commits"

--- a/configs/localdocker/node2/config.toml
+++ b/configs/localdocker/node2/config.toml
@@ -20,5 +20,5 @@ DestKeyHex = "0x0468924bd1341b5cec1fed888aaf1e3caa94e7d0f13d4f4573b01b296374b9e7
 
 [NotaryGroup]
 id = "localdocker"
-transactionTopic = "tupelo-pubsub-topics"
+transactionTopic = "tupelo-transaction-broadcast"
 commitTopic = "tupelo-pubsub-commits"

--- a/configs/localdocker/rpcserver/config.toml
+++ b/configs/localdocker/rpcserver/config.toml
@@ -16,5 +16,5 @@ DestKeyHex = "0x0468924bd1341b5cec1fed888aaf1e3caa94e7d0f13d4f4573b01b296374b9e7
 
 [NotaryGroup]
 id = "localdocker"
-transactionTopic = "tupelo-pubsub-topics"
+transactionTopic = "tupelo-transaction-broadcast"
 commitTopic = "tupelo-pubsub-commits"

--- a/gossip3/actors/conflictset.go
+++ b/gossip3/actors/conflictset.go
@@ -1,14 +1,15 @@
 package actors
 
 import (
-	"github.com/quorumcontrol/tupelo-go-sdk/consensus"
-	"github.com/quorumcontrol/messages/build/go/signatures"
 	"bytes"
 	"context"
 	"fmt"
 	"math"
 	"reflect"
 	"time"
+
+	"github.com/quorumcontrol/messages/build/go/signatures"
+	"github.com/quorumcontrol/tupelo-go-sdk/consensus"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/bls"
 

--- a/gossip3/actors/tupelo.go
+++ b/gossip3/actors/tupelo.go
@@ -131,21 +131,23 @@ func (tn *TupeloNode) validateTransaction(context actor.Context, msg *messages.V
 }
 
 func (tn *TupeloNode) handleGetTip(context actor.Context, msg *services.GetTipRequest) {
-	tn.Log.Debugw("handleGetTip", "tip", msg.ChainId)
+	tn.Log.Debugw("handleGetTip", "chainId", msg.ChainId)
 	currStateBits, err := tn.cfg.CurrentStateStore.Get([]byte(msg.ChainId))
 	if err != nil {
-		tn.Log.Errorw("error getting tip", "err", err)
+		tn.Log.Errorw("error getting tip", "chainId", msg.ChainId, "err", err)
 		return
 	}
 
 	currState := &signatures.CurrentState{}
-
 	if len(currStateBits) > 0 {
+		tn.Log.Debugw("could get current state for chain tree", "chainId", msg.ChainId)
 		err = proto.Unmarshal(currStateBits, currState)
 		if err != nil {
 			tn.Log.Errorw("error unmarshaling CurrentState", "err", err)
 			return
 		}
+	} else {
+		tn.Log.Debugw("couldn't get current state for chain tree", "chainId", msg.ChainId)
 	}
 
 	context.Respond(currState)

--- a/nodebuilder/example.toml
+++ b/nodebuilder/example.toml
@@ -25,7 +25,7 @@ DestKeyHex = "0x0438b196bddb9c3ec395b8ccb07bdab44ec768c084e7141b09ac5638d47fffbd
 id = "did:tupelo:exampleonly"
 transactionToken = "sometoken"
 burnAmount = 100
-transactionTopic = "tupelo-pubsub-topics"
+transactionTopic = "tupelo-transaction-broadcast"
 commitTopic = "tupelo-pubsub-commits"
 validatorGenerators = [
     "ISOWNER",


### PR DESCRIPTION
Make configuration files use default `transactionTopic`, for Go SDK integration tests to work.