### PR TITLE
Dockerfile: Build dynamic executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --no-cache --update build-base
 
 COPY . .
 
-RUN go install -mod=vendor -v -a -ldflags '-extldflags "-static"' -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}"
+RUN go install -mod=vendor -v -a -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}"
 
 FROM alpine:3.9
 LABEL maintainer="dev@quorumcontrol.com"


### PR DESCRIPTION
Dockerfile: Build dynamic executable, to be able to switch out DNS subsystem as this is necessary under k8s.