### PR TITLE
Increase debug logging

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,18 +106,16 @@ var rootCmd = &cobra.Command{
 			panic(err.Error())
 		}
 		log.Root().SetHandler(log.LvlFilterHandler(log.Lvl(logLevel), log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
-		err = ipfslogging.SetLogLevel("*", strings.ToUpper(logLvlName))
-		if err != nil {
+		if err := ipfslogging.SetLogLevel("*", strings.ToUpper(logLvlName)); err != nil {
 			fmt.Println("unknown ipfs log level")
 		}
 
-		if err = gossip3.SetLogLevel(zapLogLevels[logLvlName]); err != nil {
+		if err := gossip3.SetLogLevel(zapLogLevels[logLvlName]); err != nil {
 			panic(err)
 		}
 
 		if configFilePath != "" {
-			err = loadTomlConfig(configFilePath)
-			if err != nil {
+			if err := loadTomlConfig(configFilePath); err != nil {
 				panic(err)
 			}
 		}

--- a/gossip3/actors/tupelo.go
+++ b/gossip3/actors/tupelo.go
@@ -104,6 +104,7 @@ func (tn *TupeloNode) handleNewTransaction(context actor.Context) {
 		}
 	case *services.AddBlockRequest:
 		// broadcaster has sent us a fresh transaction
+		tn.Log.Debugw("received block request message")
 		tn.validateTransaction(context, &messages.ValidateTransaction{
 			Transaction: msg,
 		})

--- a/gossip3/actors/validator.go
+++ b/gossip3/actors/validator.go
@@ -85,6 +85,7 @@ func (tv *TransactionValidator) nextHeight(ObjectId []byte) uint64 {
 func (tv *TransactionValidator) handleRequest(actorCtx actor.Context, msg *validationRequest) {
 	t := msg.transaction
 
+	tv.Log.Debugw("handling validation request")
 	wrapper := &messages.TransactionWrapper{
 		Transaction: t,
 		PreFlight:   false,
@@ -116,8 +117,11 @@ func (tv *TransactionValidator) handleRequest(actorCtx actor.Context, msg *valid
 			panic(fmt.Sprintf("error unmarshaling: %v", err))
 		}
 		if expectedHeight == t.Height {
+			tv.Log.Debugw("transaction is for expected height")
 			currTip = currentState.Signature.NewTip
 		} else if expectedHeight < t.Height {
+			tv.Log.Debugw("transaction has higher than expected height, marking as preflight",
+				"height", t.Height, "expectedHeight", expectedHeight)
 			wrapper.PreFlight = true
 			actorCtx.Respond(wrapper)
 			return
@@ -127,18 +131,18 @@ func (tv *TransactionValidator) handleRequest(actorCtx actor.Context, msg *valid
 			actorCtx.Respond(wrapper)
 			return
 		}
-	} else {
-		if t.Height != 0 {
-			wrapper.PreFlight = true
-			actorCtx.Respond(wrapper)
-			return
-		}
+	} else if t.Height > 0 {
+		tv.Log.Debugw("object corresponding to transaction not found, marking as preflight",
+			"height", t.Height)
+		wrapper.PreFlight = true
+		actorCtx.Respond(wrapper)
+		return
 	}
 
 	block := &chaintree.BlockWithHeaders{}
 	err = cbornode.DecodeInto(t.Payload, block)
 	if err != nil {
-		tv.Log.Errorw("invalid transaction: payload is not a block")
+		tv.Log.Errorw("invalid transaction: payload is not a block", "err", err)
 		actorCtx.Respond(wrapper)
 		return
 	}

--- a/gossip3/tupelo_integration_test.go
+++ b/gossip3/tupelo_integration_test.go
@@ -123,9 +123,9 @@ func newSystemWithRemotes(ctx context.Context, bootstrap p2p.Node, indexOfLocal 
 	remote.NewRouter(node)
 
 	syncer, err := actor.SpawnNamed(actors.NewTupeloNodeProps(&actors.TupeloConfig{
-		Self:              localSigner,
-		NotaryGroup:       ng,
-		CurrentStateStore: currentStore,
+		Self:                     localSigner,
+		NotaryGroup:              ng,
+		CurrentStateStore:        currentStore,
 		PubSubSystem:      remote.NewNetworkPubSub(node),
 	}), "tupelo-"+localSigner.ID)
 	if err != nil {

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/quorumcontrol/tupelo-go-sdk/tracing"
 
+	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/middleware"
 	"github.com/quorumcontrol/tupelo/gossip3/actors"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
@@ -117,6 +118,7 @@ func (nb *NodeBuilder) startSigner(ctx context.Context) error {
 
 	currentPath := signerCurrentPath(nb.Config.StoragePath, localSigner)
 
+	middleware.Log.Debugw("starting signer node", "storagePath", currentPath)
 	badgerCurrent, err := storage.NewDefaultBadger(currentPath)
 	if err != nil {
 		return fmt.Errorf("error creating storage: %v", err)
@@ -254,7 +256,11 @@ func (nb *NodeBuilder) p2pNodeWithOpts(ctx context.Context, addlOpts ...p2p.Opti
 	}
 
 	if nb.Config.PublicIP != "" {
+		middleware.Log.Debugw("configuring host with public IP", "publicIP", nb.Config.PublicIP,
+			"port", nb.Config.Port)
 		opts = append(opts, p2p.WithExternalIP(nb.Config.PublicIP, nb.Config.Port))
+	} else {
+		middleware.Log.Debugw("host has no public IP")
 	}
 	return p2p.NewHostFromOptions(ctx, append(opts, addlOpts...)...)
 }


### PR DESCRIPTION
Increase amount of debug logs, which proved very helpful in debugging e.g. why transactions were ignored by signers in the k8s environment.