### PR TITLE
tupelo-go-sdk with messages notary group config

### DIFF
--- a/configs/localdocker/benchmark/config.toml
+++ b/configs/localdocker/benchmark/config.toml
@@ -1,5 +1,1 @@
-BootstrapNodes = [
-    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
-]
-
 NotaryGroupConfig = "../localdocker.toml"

--- a/configs/localdocker/bootstrap/config.toml
+++ b/configs/localdocker/bootstrap/config.toml
@@ -1,8 +1,5 @@
 Port = 34001
 BootstrapOnly = true
-BootstrapNodes = [
-    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
-]
 NotaryGroupConfig = "../localdocker.toml"
 
 [PrivateKeySet]

--- a/configs/localdocker/localdocker.toml
+++ b/configs/localdocker/localdocker.toml
@@ -1,4 +1,7 @@
 id = "localdocker"
+BootstrapAddresses = [
+    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
+]
 [[signers]]
 VerKeyHex = "0x15796b266a7d6b7c6b29c5bf97ad376fe8457e4d56bb0612ec8703c65ca7b6bb5dca004d55f5238d7764cd100c9e9cac3c5abce902bae8a5f9c29de716a145595b071b1b7038a48b4f6f88e7664b38c02062f64b3ceb499e4cbb82361457dcd731f5b48901871e7fd56a9c91ab3e06d3f7cb27288962686d9a05e02c1482f01f"
 DestKeyHex = "0x04f6dee3f7da1da58afd6ee58ea6b858fb67664fc6e2240bb6e3a75c0e1db9bbef5f413c8604bb864513d3cf27eca60b539b048b2a08f8799570c14dfb73f3f391"

--- a/configs/localdocker/node0/config.toml
+++ b/configs/localdocker/node0/config.toml
@@ -1,6 +1,3 @@
-BootstrapNodes = [
-    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
-]
 NotaryGroupConfig = "../localdocker.toml"
 
 [PrivateKeySet]

--- a/configs/localdocker/node1/config.toml
+++ b/configs/localdocker/node1/config.toml
@@ -1,6 +1,3 @@
-BootstrapNodes = [
-    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
-]
 NotaryGroupConfig = "../localdocker.toml"
 
 

--- a/configs/localdocker/node2/config.toml
+++ b/configs/localdocker/node2/config.toml
@@ -1,6 +1,3 @@
-BootstrapNodes = [
-    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
-]
 NotaryGroupConfig = "../localdocker.toml"
 
 [PrivateKeySet]

--- a/configs/localdocker/rpcserver/config.toml
+++ b/configs/localdocker/rpcserver/config.toml
@@ -1,4 +1,1 @@
-BootstrapNodes = [
-    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
-]
 NotaryGroupConfig = "../localdocker.toml"

--- a/go.mod
+++ b/go.mod
@@ -33,8 +33,8 @@ require (
 	github.com/opentracing/opentracing-go v1.1.0
 	github.com/prometheus/common v0.6.0 // indirect
 	github.com/quorumcontrol/chaintree v0.0.0-20190701175144-f8f44c3e6d4b
-	github.com/quorumcontrol/messages/build/go v0.0.0-20190716095704-9acdbae78c93
-	github.com/quorumcontrol/tupelo-go-sdk v0.5.1
+	github.com/quorumcontrol/messages/build/go v0.0.0-20190722093818-0def9b3a6501
+	github.com/quorumcontrol/tupelo-go-sdk v0.5.2
 	github.com/rs/cors v1.6.0 // indirect
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/spf13/cobra v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -505,10 +505,10 @@ github.com/quorumcontrol/chaintree v0.0.0-20190701175144-f8f44c3e6d4b/go.mod h1:
 github.com/quorumcontrol/go-libp2p-pubsub v0.0.4-0.20190528094025-e4e719f73e7a h1:XDXN6yY9PODqRMHFupyf44BQOTvCetoTG0ypXPOQzqs=
 github.com/quorumcontrol/go-libp2p-pubsub v0.0.4-0.20190528094025-e4e719f73e7a/go.mod h1:ZwlKzRSe1eGvSIdU5bD7+8RZN/Uzw0t1Bp9R1znpR/Q=
 github.com/quorumcontrol/messages/build/go v0.0.0-20190530182608-30c127bffefb/go.mod h1:b8jDN8PulcGcRJ2pQc0lbC3tPaOspGHoBIbPxfB7Jqg=
-github.com/quorumcontrol/messages/build/go v0.0.0-20190716095704-9acdbae78c93 h1:G1VRZKIZMjG00VXDK2xpv+fj2/3cKPwRPZpK/ofb1OE=
-github.com/quorumcontrol/messages/build/go v0.0.0-20190716095704-9acdbae78c93/go.mod h1:QLQVe/V3WcoFNglaJXmoRNs8u+KbsNd5MXeOaa77zgw=
-github.com/quorumcontrol/tupelo-go-sdk v0.5.1 h1:Wj8pKSyriqVMcPu2e4bWfE5Ugjk6o8TlIhWwj83b9ks=
-github.com/quorumcontrol/tupelo-go-sdk v0.5.1/go.mod h1:BkTYlHENbjO3chiFRtL+7mlDrK0SLLkdC0j8ODLQ2ZE=
+github.com/quorumcontrol/messages/build/go v0.0.0-20190722093818-0def9b3a6501 h1:+ye7Fu4SfzFZFzFAPzXFfjHndQbIYB6BMvXG3Bm34x0=
+github.com/quorumcontrol/messages/build/go v0.0.0-20190722093818-0def9b3a6501/go.mod h1:QLQVe/V3WcoFNglaJXmoRNs8u+KbsNd5MXeOaa77zgw=
+github.com/quorumcontrol/tupelo-go-sdk v0.5.2 h1:eDsshQ/FQF85adofDSLXETwXOKfsua6Jm2/79x1+NwA=
+github.com/quorumcontrol/tupelo-go-sdk v0.5.2/go.mod h1:nDi093vRZ1FZxue5UiMRgx+6YG/aMfxX7wih8gZ3OO0=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/nodebuilder/humanconfig.go
+++ b/nodebuilder/humanconfig.go
@@ -49,8 +49,7 @@ type HumanConfig struct {
 	PublicIP          string
 	Port              int
 
-	PrivateKeySet  *HumanPrivateKeySet
-	BootstrapNodes []string
+	PrivateKeySet *HumanPrivateKeySet
 
 	BootstrapOnly bool
 	TracingSystem string
@@ -58,12 +57,11 @@ type HumanConfig struct {
 
 func HumanConfigToConfig(hc HumanConfig) (*Config, error) {
 	c := &Config{
-		Namespace:      hc.Namespace,
-		StoragePath:    hc.StoragePath,
-		PublicIP:       hc.PublicIP,
-		Port:           hc.Port,
-		BootstrapNodes: hc.BootstrapNodes,
-		BootstrapOnly:  hc.BootstrapOnly,
+		Namespace:     hc.Namespace,
+		StoragePath:   hc.StoragePath,
+		PublicIP:      hc.PublicIP,
+		Port:          hc.Port,
+		BootstrapOnly: hc.BootstrapOnly,
 	}
 
 	tomlBits, err := ioutil.ReadFile(hc.NotaryGroupConfig)
@@ -71,17 +69,13 @@ func HumanConfigToConfig(hc HumanConfig) (*Config, error) {
 		return nil, fmt.Errorf("error reading %s: %v", hc.NotaryGroupConfig, err)
 	}
 
-	var humanNG types.HumanConfig
-	_, err = toml.Decode(string(tomlBits), &humanNG)
+	ngConfig, err := types.TomlToConfig(string(tomlBits))
 	if err != nil {
-		return nil, fmt.Errorf("error decoding toml: %v", err)
-	}
-
-	ngConfig, err := types.HumanConfigToConfig(&humanNG)
-	if err != nil {
-		return nil, fmt.Errorf("error getting notary group config: %v", err)
+		return nil, fmt.Errorf("error loading notary group config")
 	}
 	c.NotaryGroupConfig = ngConfig
+
+	c.BootstrapNodes = ngConfig.BootstrapAddresses
 
 	switch hc.TracingSystem {
 	case "":

--- a/nodebuilder/humanconfig_test.go
+++ b/nodebuilder/humanconfig_test.go
@@ -3,13 +3,16 @@ package nodebuilder
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestTomlLoading(t *testing.T) {
 	c, err := TomlToConfig("testconfigs/basic.toml")
 	require.Nil(t, err)
-	require.Len(t, c.NotaryGroupConfig.Signers, 2)
+	assert.Len(t, c.NotaryGroupConfig.Signers, 2)
+	assert.Equal(t, c.BootstrapNodes, []string{"/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"})
 }
 
 func TestFailsWithInvalidTracer(t *testing.T) {

--- a/nodebuilder/testconfigs/basic.toml
+++ b/nodebuilder/testconfigs/basic.toml
@@ -3,9 +3,6 @@ PublicIP = "0.0.0.0"
 Port = 0
 StoragePath = "somewhereundertherainbow"
 BootstrapOnly = false
-BootstrapNodes = [
-    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
-]
 
 TracingSystem = "jaeger"
 NotaryGroupConfig = "./ng.toml"

--- a/nodebuilder/testconfigs/ng.toml
+++ b/nodebuilder/testconfigs/ng.toml
@@ -11,6 +11,9 @@ validatorGenerators = [
 transactions = [
     "SETDATA",
 ]
+BootstrapAddresses = [
+    "/ip4/172.16.238.10/tcp/34001/ipfs/16Uiu2HAm3TGSEKEjagcCojSJeaT5rypaeJMKejijvYSnAjviWwV5"
+]
 [[signers]]
 VerKeyHex = "0x15796b266a7d6b7c6b29c5bf97ad376fe8457e4d56bb0612ec8703c65ca7b6bb5dca004d55f5238d7764cd100c9e9cac3c5abce902bae8a5f9c29de716a145595b071b1b7038a48b4f6f88e7664b38c02062f64b3ceb499e4cbb82361457dcd731f5b48901871e7fd56a9c91ab3e06d3f7cb27288962686d9a05e02c1482f01f"
 DestKeyHex = "0x04f6dee3f7da1da58afd6ee58ea6b858fb67664fc6e2240bb6e3a75c0e1db9bbef5f413c8604bb864513d3cf27eca60b539b048b2a08f8799570c14dfb73f3f391"


### PR DESCRIPTION
move to tupelo-go-sdk and messges repo with the new bootstrap addresses on the notary group itself, sets us up for single file configs for notary groups