### PR TITLE
fix docker build workflows

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,31 +1,49 @@
 on: push
 name: Docker Build & Push
 jobs:
-  privateGoMod:
-    name: Private Go Mod
-    runs-on: ubuntu-latest
+  docker:
+    name: "docker build & push"
+    runs-on: ubuntu-18.04
+    env:
+      # ${{ runner.workspace }} is not available here, so hardcode for now
+      # setup-go is considering inject these env vars automatically
+      GOPATH: /home/runner/work/tupelo/go
+      GOBIN: /home/runner/work/tupelo/go/bin
     steps:
-    - name: Install protobuf compiler
+    - name: install go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: install system dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y protobuf-compiler
-    - uses: actions/checkout@master
+        sudo apt-get install -y protobuf-compiler make
+    - uses: actions/checkout@v1
+    - uses: actions/cache@v1
+      id: vendor-cache
+      with:
+        path: vendor/
+        key: go-vendor-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-vendor-
     - name: git setup
       run: scripts/ci-gitsetup.sh
-    - name: Prepare Build Environment
-      uses: ./.github/actions/make
       env:
         SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+    - name: vendor dependencies
+      if: steps.vendor-cache.outputs.cache-hit != 'true'
+      run: make vendor
+    - name: set version
+      run: make github-prepare
+      env:
         GITHUB_REF: ${{ github.ref }}
-      with:
-        args: github-prepare
-    - name: Docker Login
+    - name: docker login
       run: docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    - name: Build & Push
-      run: scripts/ci-dockerbuildpush.sh
-      env:
-        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-        GITHUB_REF: ${{ github.ref }}
+    - name: docker build and push
+      run: |
+        IMAGE_REF=$(echo "${{ github.ref }}" | rev | cut -d / -f 1 | rev)
+        docker build -t quorumcontrol/tupelo:${IMAGE_REF} .
+        docker push quorumcontrol/tupelo:${IMAGE_REF}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,43 +1,50 @@
 on: release
 name: Docker Build & Push Latest
 jobs:
-  privateGoMod:
-    name: Private Go Mod
-    runs-on: ubuntu-latest
+  docker:
+    name: "docker build & push latest"
+    runs-on: ubuntu-18.04
+    env:
+      # ${{ runner.workspace }} is not available here, so hardcode for now
+      # setup-go is considering inject these env vars automatically
+      GOPATH: /home/runner/work/tupelo/go
+      GOBIN: /home/runner/work/tupelo/go/bin
     steps:
-    - uses: actions/checkout@master
-    - name: Private Go Mod
-      uses: ./.github/actions/make
+    - name: install go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+    - name: install system dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y protobuf-compiler make
+    - uses: actions/checkout@v1
+    - uses: actions/cache@v1
+      id: vendor-cache
+      with:
+        path: vendor/
+        key: go-vendor-${{ hashFiles('go.sum') }}
+        restore-keys: |
+          go-vendor-
+    - name: git setup
+      run: scripts/ci-gitsetup.sh
       env:
         SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      with:
-        args: vendor
-    - name: Prepare Build Environment
-      uses: ./.github/actions/make
+    - name: vendor dependencies
+      if: steps.vendor-cache.outputs.cache-hit != 'true'
+      run: make vendor
+    - name: run tests
+      run: scripts/test-suite.sh
+    - name: set version
+      run: make github-prepare
       env:
-        SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
-      with:
-        args: github-prepare
-    - name: Docker Login
-      uses: actions/docker/login@8cdf801b322af5f369e00d85e9cf3a7122f49108
+        GITHUB_REF: ${{ github.ref }}
+    - name: docker login
+      run: docker login --username "$DOCKER_USERNAME" --password "$DOCKER_PASSWORD"
       env:
         DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
-    - name: Docker Build Container
-      uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: build -t imagebuild .
-    - name: Docker Tag Images
-      uses: actions/docker/tag@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: imagebuild quorumcontrol/tupelo
-    - name: On Latest Release
-      uses: ./.github/actions/filters
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        args: latest-release
-    - name: Docker Push Latest Image
-      uses: actions/docker/cli@8cdf801b322af5f369e00d85e9cf3a7122f49108
-      with:
-        args: push quorumcontrol/tupelo:latest
+    - name: docker build and push
+      run: |
+        docker build -t quorumcontrol/tupelo:latest .
+        docker push quorumcontrol/tupelo:latest


### PR DESCRIPTION
This largely copies the steps from the ci testing workflow in https://github.com/quorumcontrol/tupelo/pull/356, for building branch and release docker images. 
 Certainly a _bit_ of duplication here for now, but this at least gets everything working again.

I looked at using [github action artifacts](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/persisting-workflow-data-using-artifacts) to pass state on a multi-job process on push, which would store the "prepared" working directory (vendor, packr, proto, etc) into an artifact, and then load that up for the docker builds. However, the storage is limited to `2GB` and I could not find a way to manually purge an artifact. 

Similarly you can do `actions/cache`, but that automatically purges after 2GB of rolling usage and has a 400mb limit per file, which seemed like it could start behaving wonky without insight.

Also, I feel that having a branch's docker image NOT blocked by passing tests is actually helpful if you are trying to debug. But I made the release action blocked by passing tests. So all in all, not exactly duplicated, but areas we can DRY up in the future as we master the github actions universe.

depends on: https://github.com/quorumcontrol/tupelo/pull/356