### PR TITLE
Try increasing bootstrap timeout for CI

### DIFF
--- a/gossip3/tupelo_integration_test.go
+++ b/gossip3/tupelo_integration_test.go
@@ -324,7 +324,7 @@ func setUpSystem(t *testing.T) (*remote.NetworkPubSub, *types.NotaryGroup, func(
 	if err != nil {
 		return nil, nil, cleanUp, err
 	}
-	err = clientHost.WaitForBootstrap(2, 1*time.Second)
+	err = clientHost.WaitForBootstrap(2, 5*time.Second)
 	if err != nil {
 		return nil, nil, cleanUp, err
 	}


### PR DESCRIPTION
This seems to have fixed the GH Actions CI failure I was seeing.