### PR TITLE
Don't require SignKey for bootstrap node

### DIFF
--- a/nodebuilder/humanconfig.go
+++ b/nodebuilder/humanconfig.go
@@ -19,10 +19,15 @@ type HumanPrivateKeySet struct {
 }
 
 func (hpks *HumanPrivateKeySet) ToPrivateKeySet() (*PrivateKeySet, error) {
-	signKeyBytes, err := hexutil.Decode(hpks.SignKeyHex)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding sign key: %v", err)
+	var signKey *bls.SignKey
+	if hpks.SignKeyHex != "" {
+		signKeyBytes, err := hexutil.Decode(hpks.SignKeyHex)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding sign key: %v", err)
+		}
+		signKey = bls.BytesToSignKey(signKeyBytes)
 	}
+
 	destKeyBytes, err := hexutil.Decode(hpks.DestKeyHex)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding dest key: %v", err)
@@ -31,7 +36,6 @@ func (hpks *HumanPrivateKeySet) ToPrivateKeySet() (*PrivateKeySet, error) {
 	if err != nil {
 		return nil, fmt.Errorf("couldn't unmarshal ECDSA private key: %v", err)
 	}
-	signKey := bls.BytesToSignKey(signKeyBytes)
 	return &PrivateKeySet{
 		SignKey: signKey,
 		DestKey: ecdsaPrivate,

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -111,6 +111,10 @@ func (nb *NodeBuilder) StartTracing() {
 
 func (nb *NodeBuilder) startSigner(ctx context.Context) error {
 	localKeys := nb.Config.PrivateKeySet
+	if localKeys.SignKey == nil {
+		return fmt.Errorf("must set sign key for signer")
+	}
+
 	localSigner := types.NewLocalSigner(&localKeys.DestKey.PublicKey, localKeys.SignKey)
 
 	currentPath := signerCurrentPath(nb.Config.StoragePath, localSigner)


### PR DESCRIPTION
`HumanConfig` was requiring a `SignKeyHex` to be valid, but bootstrap nodes don't need it. This makes it handle empty cases and throws and error on signer spinup if its empty