### PR TITLE
Install ca-certs in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.12.4-alpine3.9 AS build
+FROM golang:1.13.5-alpine3.10 AS build
 
 WORKDIR /app
 
@@ -8,10 +8,10 @@ COPY . .
 
 RUN go install -mod=vendor -v -a -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}"
 
-FROM alpine:3.9
+FROM alpine:3.10
 LABEL maintainer="dev@quorumcontrol.com"
 
-RUN apk add --no-cache --update gettext
+RUN apk add --no-cache --update gettext ca-certificates
 
 RUN mkdir -p /tupelo
 

--- a/go.mod
+++ b/go.mod
@@ -40,5 +40,5 @@ require (
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20191111213947-16651526fdb4
 	google.golang.org/genproto v0.0.0-20190611190212-a7e196e89fd3 // indirect
-	google.golang.org/grpc v1.21.1
+	google.golang.org/grpc v1.21.1 // indirect
 )


### PR DESCRIPTION
This fixes sending elastic APM data to our Elastic APM cluster (which is behind an ALB w/ an AWS-provisioned cert). Before installing this I was getting `x509: certificate signed by unknown authority` errors from the elastic APM client library when it tried to publish.

I also took the opportunity to update the Go and Alpine versions.