### PR TITLE
actually validate the gossip3 incoming transactions

### DIFF
--- a/gossip3to4/node.go
+++ b/gossip3to4/node.go
@@ -11,6 +11,7 @@ import (
 	"github.com/quorumcontrol/messages/v2/build/go/services"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/types"
 	"github.com/quorumcontrol/tupelo-go-sdk/p2p"
+	"github.com/quorumcontrol/tupelo/gossip4"
 )
 
 type NodeConfig struct {
@@ -24,16 +25,25 @@ type Node struct {
 	notaryGroup *types.NotaryGroup
 	gossip3Sub  *actor.PID
 	gossip4Node *actor.PID
+	validator   *gossip4.TransactionValidator
 	logger      logging.EventLogger
 }
 
 func NewNode(ctx context.Context, cfg *NodeConfig) *Node {
 	logger := logging.Logger("gossip3to4")
 
+	// purposely setting the node PID to nil because we send in the ABR
+	// from this node as opposed to using the validator itself to send in the Tx
+	validator, err := gossip4.NewTransactionValidator(logger, cfg.NotaryGroup, nil)
+	if err != nil {
+		panic(fmt.Errorf("error creating new transaction validator: %w", err))
+	}
+
 	return &Node{
 		p2pNode:     cfg.P2PNode,
 		notaryGroup: cfg.NotaryGroup,
 		gossip4Node: cfg.Gossip4Node,
+		validator:   validator,
 		logger:      logger,
 	}
 }
@@ -67,7 +77,7 @@ func (n *Node) Receive(actorCtx actor.Context) {
 	case *services.AddBlockRequest:
 		// these are converted ABRs coming back from the gossip3 subscriber
 		n.logger.Debugf("received ABR: %+v", msg)
-		n.handleAddBlockRequest(actorCtx)
+		n.handleAddBlockRequest(actorCtx, msg)
 	default:
 		n.logger.Debugf("received other message: %+v", msg)
 		sp := opentracing.StartSpan("gossip3to4-node-received-other")
@@ -87,9 +97,14 @@ func (n *Node) handleStarted(actorCtx actor.Context) {
 	n.gossip3Sub = actorCtx.Spawn(NewGossip3SubscriberProps(g3sCfg))
 }
 
-func (n *Node) handleAddBlockRequest(actorCtx actor.Context) {
+func (n *Node) handleAddBlockRequest(actorCtx actor.Context, abr *services.AddBlockRequest) {
 	sp := opentracing.StartSpan("gossip3to4-received-add-block-request")
 	defer sp.Finish()
 
-	actorCtx.Forward(n.gossip4Node)
+	valid := n.validator.ValidateAbr(context.TODO(), abr)
+	if valid {
+		sp.SetTag("valid", true)
+		actorCtx.Forward(n.gossip4Node)
+	}
+	sp.SetTag("valid", false)
 }

--- a/gossip4/node.go
+++ b/gossip4/node.go
@@ -146,7 +146,7 @@ func (n *Node) Start(ctx context.Context) error {
 		n.rootContext.Poison(n.pid)
 	}()
 
-	validator, err := newTransactionValidator(n.logger, n.notaryGroup, pid)
+	validator, err := NewTransactionValidator(n.logger, n.notaryGroup, pid)
 	if err != nil {
 		return fmt.Errorf("error setting up: %v", err)
 	}

--- a/gossip4/txvalidator.go
+++ b/gossip4/txvalidator.go
@@ -26,15 +26,18 @@ import (
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip3/types"
 )
 
-type transactionValidator struct {
+// TransactionValidator validates incoming pubsub messages for internal consistency
+// and sends them to the gossip4 node. It is exported for the gossip3to4 module
+type TransactionValidator struct {
 	group      *types.NotaryGroup
 	validators []chaintree.BlockValidatorFunc
 	node       *actor.PID
 	logger     logging.EventLogger
 }
 
-func newTransactionValidator(logger logging.EventLogger, group *types.NotaryGroup, node *actor.PID) (*transactionValidator, error) {
-	tv := &transactionValidator{
+// NewTransactionValidator creates a new TransactionValidator
+func NewTransactionValidator(logger logging.EventLogger, group *types.NotaryGroup, node *actor.PID) (*TransactionValidator, error) {
+	tv := &TransactionValidator{
 		group:  group,
 		node:   node,
 		logger: logger,
@@ -46,7 +49,7 @@ func newTransactionValidator(logger logging.EventLogger, group *types.NotaryGrou
 	return tv, nil
 }
 
-func (tv *transactionValidator) setup() error {
+func (tv *TransactionValidator) setup() error {
 	validators, err := blockValidators(tv.group)
 	tv.validators = validators
 	return err
@@ -80,13 +83,13 @@ func blockValidators(group *types.NotaryGroup) ([]chaintree.BlockValidatorFunc, 
 	return append(blockValidators, sigVerifier), nil
 }
 
-func (tv *transactionValidator) validate(ctx context.Context, pID peer.ID, msg *pubsub.Message) bool {
+func (tv *TransactionValidator) validate(ctx context.Context, pID peer.ID, msg *pubsub.Message) bool {
 	abr, err := pubsubMsgToAddBlockRequest(ctx, msg)
 	if err != nil {
 		tv.logger.Errorf("error converting message to abr: %v", err)
 		return false
 	}
-	validated := tv.validateAbr(ctx, abr)
+	validated := tv.ValidateAbr(ctx, abr)
 	if validated {
 		// we do something a bit odd here and send the ABR through an actor notification rather
 		// then just letting a pubsub subscribe happen, because we've already done the decoding work.
@@ -98,7 +101,8 @@ func (tv *transactionValidator) validate(ctx context.Context, pID peer.ID, msg *
 	return false
 }
 
-func (tv *transactionValidator) validateAbr(ctx context.Context, abr *services.AddBlockRequest) bool {
+// ValidateAbr validates the internal consistency of an ABR (without validating if it is the next in the proper sequence)
+func (tv *TransactionValidator) ValidateAbr(ctx context.Context, abr *services.AddBlockRequest) bool {
 	newTip, err := cid.Cast(abr.NewTip)
 	if err != nil {
 		tv.logger.Errorf("error casting abr new tip: %v", err)

--- a/gossip4/txvalidator_test.go
+++ b/gossip4/txvalidator_test.go
@@ -30,7 +30,7 @@ func TestTransactionValidator(t *testing.T) {
 
 	fut := actor.NewFuture(5 * time.Second)
 
-	validator, err := newTransactionValidator(logging.Logger("txvalidatortest"), ng, fut.PID())
+	validator, err := NewTransactionValidator(logging.Logger("txvalidatortest"), ng, fut.PID())
 	require.Nil(t, err)
 
 	// an internally consistent Tx is marked as valid and sent to the Node
@@ -53,13 +53,13 @@ func TestTransactionValidator(t *testing.T) {
 	// an abr with a bad new tip should be marked invalid
 	abr = testhelpers.NewValidTransaction(t)
 	abr.NewTip = []byte{}
-	isValid = validator.validateAbr(ctx, &abr)
+	isValid = validator.ValidateAbr(ctx, &abr)
 	require.False(t, isValid)
 
 	// an abr with a bad height should be marked invalid
 	abr = testhelpers.NewValidTransaction(t)
 	abr.Height = 1000
-	isValid = validator.validateAbr(ctx, &abr)
+	isValid = validator.ValidateAbr(ctx, &abr)
 	require.False(t, isValid)
 }
 
@@ -87,7 +87,7 @@ func BenchmarkTransactionValidator(b *testing.B) {
 	act := actor.EmptyRootContext.Spawn(actor.PropsFromFunc(receiver))
 	defer actor.EmptyRootContext.Stop(act)
 
-	validator, err := newTransactionValidator(logging.Logger("txvalidatortest"), ng, act)
+	validator, err := NewTransactionValidator(logging.Logger("txvalidatortest"), ng, act)
 	require.Nil(b, err)
 
 	txs := make([]*pubsub.Message, b.N)


### PR DESCRIPTION
oops - we were just sending gossip3tx directly into himitsu instead of validating they were OK. This does the validation. 

A couple o' notes: 

* this will conflict (lightly) with #369 , but should be easy to fix up
* any ChainTree with state over in gossip3 land will not validate in gossip4 (I think that's OK for now but wanted to note)
* I opted to send in the tx from the gossip3to4 module rather than using the Tx validator's own send mechanism, because otherwise this would have to reserialize the new AddBlockRequest and convert it to a pubsub message and then send it over which feels more complicated.
* You can't just re-publish the new message because then every gossip4 node would rebroadcast every Tx... so you do need to keep it within the single node.