### PR TITLE
name the tupelo systems different things so they don't conflict

### DIFF
--- a/gossip/node_test.go
+++ b/gossip/node_test.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 	"time"
 
@@ -24,7 +25,8 @@ import (
 	"github.com/quorumcontrol/tupelo/testnotarygroup"
 )
 
-func newTupeloSystem(ctx context.Context, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*Node, error) {
+func newTupeloSystem(ctx context.Context, t testing.TB, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*Node, error) {
+	name := t.Name()
 	nodes := make([]*Node, len(testSet.SignKeys))
 
 	ng := types.NewNotaryGroup("testnotary")
@@ -45,6 +47,7 @@ func newTupeloSystem(ctx context.Context, testSet *testnotarygroup.TestSet) (*ty
 			SignKey:     testSet.SignKeys[i],
 			NotaryGroup: ng,
 			DagStore:    peer,
+			Name:        name + "-" + strconv.Itoa(i),
 		})
 		if err != nil {
 			return nil, nil, fmt.Errorf("error making node: %v", err)
@@ -122,7 +125,7 @@ func TestNewNode(t *testing.T) {
 
 	numMembers := 1
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	_, nodes, err := newTupeloSystem(ctx, ts)
+	_, nodes, err := newTupeloSystem(ctx, t, ts)
 	require.Nil(t, err)
 	require.Len(t, nodes, numMembers)
 	n := nodes[0]
@@ -140,7 +143,7 @@ func TestEndToEnd(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	group, nodes, err := newTupeloSystem(ctx, ts)
+	group, nodes, err := newTupeloSystem(ctx, t, ts)
 	require.Nil(t, err)
 	require.Len(t, nodes, numMembers)
 
@@ -178,7 +181,7 @@ func TestByzantineCases(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	group, nodes, err := newTupeloSystem(ctx, ts)
+	group, nodes, err := newTupeloSystem(ctx, t, ts)
 	require.Nil(t, err)
 	require.Len(t, nodes, numMembers)
 

--- a/gossip/txvalidator_test.go
+++ b/gossip/txvalidator_test.go
@@ -25,7 +25,7 @@ func TestTransactionValidator(t *testing.T) {
 
 	numMembers := 1
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	ng, nodes, err := newTupeloSystem(ctx, ts)
+	ng, nodes, err := newTupeloSystem(ctx, t, ts)
 	require.Nil(t, err)
 	require.Len(t, nodes, numMembers)
 
@@ -72,7 +72,7 @@ func BenchmarkTransactionValidator(b *testing.B) {
 
 	numMembers := 1
 	ts := testnotarygroup.NewTestSet(b, numMembers)
-	ng, nodes, err := newTupeloSystem(ctx, ts)
+	ng, nodes, err := newTupeloSystem(ctx, b, ts)
 	require.Nil(b, err)
 	require.Len(b, nodes, numMembers)
 

--- a/nodebuilder/nodebuilder_test.go
+++ b/nodebuilder/nodebuilder_test.go
@@ -30,6 +30,9 @@ func TestBootstrap(t *testing.T) {
 				},
 				BootstrapNodes: p2p.BootstrapNodes(),
 				BootstrapOnly:  true,
+				NotaryGroupConfig: &types.Config{
+					TransactionTopic: "testOnly",
+				},
 			},
 		}
 		err = nb.Start(ctx)


### PR DESCRIPTION
master had a failing CI - my guess is that the old system hadn't fully shut down when the new one is spinning up and so there is a naming conflict. This gives every system a new name so they don't conflict.