### PR TITLE
config improvements

### DIFF
--- a/cmd/node.go
+++ b/cmd/node.go
@@ -16,7 +16,13 @@ import (
 )
 
 func runGossipNode(ctx context.Context, config *nodebuilder.Config, group *types.NotaryGroup) (*actor.PID, error) {
-	p2pNode, bitswapper, err := p2p.NewHostAndBitSwapPeer(ctx, p2p.WithKey(config.PrivateKeySet.DestKey))
+	p2pNode, bitswapper, err := p2p.NewHostAndBitSwapPeer(
+		ctx,
+		p2p.WithKey(config.PrivateKeySet.DestKey),
+		// TODO: this is easier for early development of wasm, but we should examine whether
+		// we want this in production or not.
+		p2p.WithWebSockets(50000),
+	)
 	if err != nil {
 		return nil, fmt.Errorf("error creating p2p node: %v", err)
 	}

--- a/cmd/node.go
+++ b/cmd/node.go
@@ -16,7 +16,7 @@ import (
 )
 
 func runGossipNode(ctx context.Context, config *nodebuilder.Config, group *types.NotaryGroup) (*actor.PID, error) {
-	p2pNode, peer, err := p2p.NewHostAndBitSwapPeer(ctx)
+	p2pNode, bitswapper, err := p2p.NewHostAndBitSwapPeer(ctx, p2p.WithKey(config.PrivateKeySet.DestKey))
 	if err != nil {
 		return nil, fmt.Errorf("error creating p2p node: %v", err)
 	}
@@ -25,7 +25,7 @@ func runGossipNode(ctx context.Context, config *nodebuilder.Config, group *types
 		P2PNode:     p2pNode,
 		SignKey:     config.PrivateKeySet.SignKey,
 		NotaryGroup: group,
-		DagStore:    peer,
+		DagStore:    bitswapper,
 	}
 
 	node, err := gossip.NewNode(ctx, nodeCfg)
@@ -33,14 +33,16 @@ func runGossipNode(ctx context.Context, config *nodebuilder.Config, group *types
 		return nil, fmt.Errorf("error creating new node: %v", err)
 	}
 
-	err = node.Start(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error starting node: %v", err)
-	}
-
 	err = node.Bootstrap(ctx, group.Config().BootstrapAddresses)
 	if err != nil {
 		return nil, fmt.Errorf("error bootstrapping node: %v", err)
+	}
+
+	fmt.Printf("node bootstrapped, starting")
+
+	err = node.Start(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("error starting node: %v", err)
 	}
 
 	return node.PID(), nil

--- a/configs/localdocker/rpcserver/config.toml
+++ b/configs/localdocker/rpcserver/config.toml
@@ -1,1 +1,0 @@
-NotaryGroupConfig = "../localdocker.toml"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,34 +12,31 @@ services:
       - "34001:34001"
       
   node0:
+    depends_on: 
+      - bootstrap
     build: .
     volumes:
       - ./configs/localdocker:/configs
-    command: ["test-node", "--config", "/configs/node0/config.toml",
+    command: ["node", "--config", "/configs/node0/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
 
   node1:
+    depends_on: 
+      - bootstrap
     build: .
     volumes:
       - ./configs/localdocker:/configs
-    command: ["test-node", "--config", "/configs/node1/config.toml",
+    command: ["node", "--config", "/configs/node1/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
   
   node2:
+    depends_on: 
+      - bootstrap
     build: .
     volumes:
       - ./configs/localdocker:/configs
-    command: ["test-node", "--config", "/configs/node2/config.toml",
+    command: ["node", "--config", "/configs/node2/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-error}"]
-
-  rpc-server:
-    build: .
-    volumes:
-      - ./configs/localdocker:/configs
-    command: ["rpc-server","-r", "-l", "0", "--config", "/configs/rpcserver/config.toml",
-      "-L", "${TUPELO_LOG_LEVEL:-error}"]
-    ports:
-      - "50051:50051"
 
 networks:
   default:

--- a/gossip/node.go
+++ b/gossip/node.go
@@ -30,8 +30,6 @@ import (
 
 const gossipProtocol = "tupelo/v0.0.1"
 
-const transactionTopic = "g4-transactions"
-
 func init() {
 	cbornode.RegisterCborType(services.AddBlockRequest{})
 }
@@ -155,12 +153,12 @@ func (n *Node) Start(ctx context.Context) error {
 
 	n.pubsub = n.p2pNode.GetPubSub()
 
-	err = n.pubsub.RegisterTopicValidator(transactionTopic, validator.validate)
+	err = n.pubsub.RegisterTopicValidator(n.notaryGroup.Config().TransactionTopic, validator.validate)
 	if err != nil {
 		return fmt.Errorf("error registering topic validator: %v", err)
 	}
 
-	sub, err := n.pubsub.Subscribe(transactionTopic)
+	sub, err := n.pubsub.Subscribe(n.notaryGroup.Config().TransactionTopic)
 	if err != nil {
 		return fmt.Errorf("error subscribing %v", err)
 	}

--- a/gossip/node.go
+++ b/gossip/node.go
@@ -208,7 +208,7 @@ func (n *Node) Bootstrap(ctx context.Context, bootstrapAddrs []string) error {
 
 	n.closer = closer
 
-	return n.p2pNode.WaitForBootstrap(1, 5*time.Second)
+	return n.p2pNode.WaitForBootstrap(1, 10*time.Second)
 }
 
 func (n *Node) Close() error {

--- a/gossip/node_test.go
+++ b/gossip/node_test.go
@@ -140,7 +140,7 @@ func TestEndToEnd(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	_, nodes, err := newTupeloSystem(ctx, ts)
+	group, nodes, err := newTupeloSystem(ctx, ts)
 	require.Nil(t, err)
 	require.Len(t, nodes, numMembers)
 
@@ -165,7 +165,7 @@ func TestEndToEnd(t *testing.T) {
 		bits, err := abr.Marshal()
 		require.Nil(t, err)
 
-		err = nodes[i%(len(nodes)-1)].pubsub.Publish(transactionTopic, bits)
+		err = nodes[i%(len(nodes)-1)].pubsub.Publish(group.Config().TransactionTopic, bits)
 		require.Nil(t, err)
 	}
 
@@ -178,7 +178,7 @@ func TestByzantineCases(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	_, nodes, err := newTupeloSystem(ctx, ts)
+	group, nodes, err := newTupeloSystem(ctx, ts)
 	require.Nil(t, err)
 	require.Len(t, nodes, numMembers)
 
@@ -208,7 +208,7 @@ func TestByzantineCases(t *testing.T) {
 			bits, err := abr.Marshal()
 			require.Nil(t, err)
 
-			err = n.pubsub.Publish(transactionTopic, bits)
+			err = n.pubsub.Publish(group.Config().TransactionTopic, bits)
 			require.Nil(t, err)
 		}
 		waitForAllAbrs(t, ctx, nodes, abrs)

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -196,6 +196,16 @@ func (nb *NodeBuilder) startBootstrap(ctx context.Context) error {
 		}
 	}
 
+	// TODO: not sure we want this here long term, but for now let the
+	// bootstrapper help out with gossip pubsub
+	group, err := nb.NotaryGroup()
+	if err != nil {
+		return fmt.Errorf("error getting notary group %w", err)
+	}
+	_, err = host.GetPubSub().Subscribe(group.Config().TransactionTopic)
+	if err != nil {
+		return fmt.Errorf("error subscribing %w", err)
+	}
 	return nil
 }
 

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -177,6 +177,7 @@ func (nb *NodeBuilder) startBootstrap(ctx context.Context) error {
 		ctx,
 		p2p.WithLibp2pOptions(libp2p.ConnectionManager(cm)),
 		p2p.WithRelayOpts(circuit.OptHop),
+		p2p.WithWebSockets(50000), // TODO: examine whether we actually need this in bootstrap or not
 	)
 	if err != nil {
 		return fmt.Errorf("Could not start bootstrap node, %v", err)


### PR DESCRIPTION
Discovered this when starting up trying to re-do the wasm directory. 

This:

* use the destkey for the p2p node key (only way it will be reachable)
* turn on websockets for bootstrap / g4 nodes
* use notary group config for the transaction topic (stop hard-coding)
* other very minor cleanups (10s bootstrap, change order of bootstrapping, etc)