### PR TITLE
wip: switch to protobuf types

### DIFF
--- a/gossip/proofvalidater.go
+++ b/gossip/proofvalidater.go
@@ -1,0 +1,50 @@
+package gossip
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/quorumcontrol/messages/build/go/gossip"
+	"github.com/quorumcontrol/tupelo-go-sdk/bls"
+	sigfuncs "github.com/quorumcontrol/tupelo-go-sdk/signatures"
+)
+
+// This is used for verifying receiveToken transactions
+func verifyRoundConfirmation(rootCtx context.Context, conf *gossip.RoundConfirmation, verKeys []*bls.VerKey) (bool, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rootCtx, "verifyRoundConfirmation")
+	defer sp.Finish()
+
+	sig := conf.Signature
+	msg := conf.RoundCid
+
+	err := sigfuncs.RestoreBLSPublicKey(ctx, sig, verKeys)
+	if err != nil {
+		sp.SetTag("error", true)
+		return false, fmt.Errorf("error restoring public key: %v", err)
+	}
+
+	isVerified, err := sigfuncs.Valid(ctx, sig, msg, nil)
+	if err != nil {
+		sp.SetTag("error", true)
+		return false, fmt.Errorf("error verifying round signature: %v", err)
+	}
+	sp.SetTag("verified", isVerified)
+	return isVerified, nil
+}
+
+func verifyProof(rootCtx context.Context, msg []byte, proof *gossip.Proof, verKeys []*bls.VerKey) (bool, error) {
+	sp, ctx := opentracing.StartSpanFromContext(rootCtx, "validateProof")
+	defer sp.Finish()
+
+	validRoundConfirmation, err := verifyRoundConfirmation(ctx, proof.RoundConfirmation, verKeys)
+	if err != nil {
+		return false, fmt.Errorf("error verifying round confirmation: %v", err)
+	}
+
+	if !validRoundConfirmation {
+		return false, nil
+	}
+
+	return false, nil
+}

--- a/gossip/vote.go
+++ b/gossip/vote.go
@@ -5,7 +5,7 @@ import "github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
 var ZeroVoteID = "n"
 
 type Vote struct {
-	Checkpoint *types.Checkpoint
+	Checkpoint *types.WrappedCheckpoint
 	tallyCount float64
 	id         string
 }


### PR DESCRIPTION
This is a draft pull request that refactors the gossip4 types into messages so that we can use them to validate receive token transactions. What's left to do here is to finish wrapping the `Checkpoint` type to cache the cbor representation within the app, and then flesh out the proof validater