### PR TITLE
use go-log for all logging

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/quorumcontrol/chaintree v0.9.4
 	github.com/quorumcontrol/messages v1.1.1
 	github.com/quorumcontrol/messages/v2 v2.1.2
-	github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200113203129-833be754e51a
+	github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200120024519-21cd48d8c6e6
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -791,6 +791,8 @@ github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200113102443-c8486f4a8c4
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200113102443-c8486f4a8c46/go.mod h1:yGMtIJDFSATAZTAwUvmhOgQd7qf0tGZbUgdQm/oGdKc=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200113203129-833be754e51a h1:PIzhtSEhgK3hZ2GQsrcdih72VXWuCBJe0UuOi3Pneyo=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200113203129-833be754e51a/go.mod h1:yGMtIJDFSATAZTAwUvmhOgQd7qf0tGZbUgdQm/oGdKc=
+github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200120024519-21cd48d8c6e6 h1:WITJ8C4bwr8cDzKB6rECnnfXq0JnVHnIhHvQ2fRW/1A=
+github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200120024519-21cd48d8c6e6/go.mod h1:yGMtIJDFSATAZTAwUvmhOgQd7qf0tGZbUgdQm/oGdKc=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
-	"github.com/quorumcontrol/tupelo-go-sdk/gossip/middleware"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
 	"github.com/quorumcontrol/tupelo-go-sdk/tracing"
 	"github.com/quorumcontrol/tupelo/gossip"
@@ -257,8 +256,7 @@ func (nb *NodeBuilder) defaultP2POptions(ctx context.Context) []p2p.Option {
 	}
 
 	if nb.Config.PublicIP != "" {
-		middleware.Log.Debugw("configuring host with public IP", "publicIP", nb.Config.PublicIP,
-			"port", nb.Config.Port)
+		logger.Debugf("configuring host with public IP: %v and port: %v", nb.Config.PublicIP, nb.Config.Port)
 		opts = append(opts, p2p.WithExternalIP(nb.Config.PublicIP, nb.Config.Port))
 	} else {
 		logger.Debug("host has no public IP")


### PR DESCRIPTION
Small change to account for removing the `...gossip/middleware` package from tupelo-go-sdk.