### PR TITLE
Fix gossip4 validator

### DIFF
--- a/gossip/node.go
+++ b/gossip/node.go
@@ -464,7 +464,7 @@ func (n *Node) handleStream(s network.Stream) {
 
 func (n *Node) handleAddBlockRequest(actorContext actor.Context, abrWrapper *AddBlockWrapper) {
 	abr := abrWrapper.AddBlockRequest
-	sp := abrWrapper.NewSpan("g4.handleAddBlockRequest")
+	sp := abrWrapper.NewSpan("gossip4.handleAddBlockRequest")
 	defer sp.Finish()
 
 	ctx, cancel := context.WithCancel(abrWrapper.GetContext())

--- a/gossip/txvalidator.go
+++ b/gossip/txvalidator.go
@@ -109,7 +109,7 @@ func (tv *TransactionValidator) validate(ctx context.Context, pID peer.ID, msg *
 }
 
 func (tv *TransactionValidator) ValidateAbr(validateCtx context.Context, abr *services.AddBlockRequest) bool {
-	sp, ctx := opentracing.StartSpanFromContext(validateCtx, "gossip4.unmarshalPubSub")
+	sp, ctx := opentracing.StartSpanFromContext(validateCtx, "gossip4.validateABR")
 	defer sp.Finish()
 
 	newTip, err := cid.Cast(abr.NewTip)

--- a/gossip/txvalidator.go
+++ b/gossip/txvalidator.go
@@ -201,6 +201,8 @@ func (tv *TransactionValidator) ValidateAbr(validateCtx context.Context, abr *se
 		return false
 	}
 
+	sp.SetTag("tips-match", true)
+
 	return true
 }
 

--- a/gossip/txvalidator.go
+++ b/gossip/txvalidator.go
@@ -109,7 +109,7 @@ func (tv *TransactionValidator) validate(ctx context.Context, pID peer.ID, msg *
 }
 
 func (tv *TransactionValidator) ValidateAbr(validateCtx context.Context, abr *services.AddBlockRequest) bool {
-	sp, ctx := opentracing.StartSpanFromContext(validateCtx, "g4.unmarshalPubSub")
+	sp, ctx := opentracing.StartSpanFromContext(validateCtx, "gossip4.unmarshalPubSub")
 	defer sp.Finish()
 
 	newTip, err := cid.Cast(abr.NewTip)
@@ -197,6 +197,7 @@ func (tv *TransactionValidator) ValidateAbr(validateCtx context.Context, abr *se
 	}
 
 	if !chainTree.Dag.Tip.Equals(newTip) {
+		sp.SetTag("tips-match", false)
 		return false
 	}
 
@@ -204,7 +205,7 @@ func (tv *TransactionValidator) ValidateAbr(validateCtx context.Context, abr *se
 }
 
 func pubsubMsgToAddBlockRequest(ctx context.Context, msg *pubsub.Message) (*services.AddBlockRequest, error) {
-	sp, _ := opentracing.StartSpanFromContext(ctx, "g4.unmarshalPubSub")
+	sp, _ := opentracing.StartSpanFromContext(ctx, "gossip4.unmarshalPubSub")
 	defer sp.Finish()
 
 	abr := &services.AddBlockRequest{}

--- a/gossip3to4/addblockrequest.go
+++ b/gossip3to4/addblockrequest.go
@@ -12,6 +12,8 @@ import (
 	g4services "github.com/quorumcontrol/messages/v2/build/go/services"
 	g4signatures "github.com/quorumcontrol/messages/v2/build/go/signatures"
 	"github.com/quorumcontrol/tupelo-go-sdk/consensus"
+
+	"github.com/quorumcontrol/tupelo/gossip"
 )
 
 type g3SignatureMap map[string]*g3signatures.Signature
@@ -73,7 +75,7 @@ func ConvertABR(abr *g3services.AddBlockRequest) (*g4services.AddBlockRequest, e
 		ObjectId:    abr.ObjectId,
 		PreviousTip: abr.PreviousTip,
 		Height:      abr.Height,
-		NewTip:      abr.NewTip,
+		NewTip:      []byte(gossip.MagicValidNewTip), // just for dark traffic testing
 		Payload:     g4PayloadBytes,
 		State:       abr.State,
 	}, nil

--- a/gossip3to4/addblockrequest_test.go
+++ b/gossip3to4/addblockrequest_test.go
@@ -7,6 +7,8 @@ import (
 	cbornode "github.com/ipfs/go-ipld-cbor"
 	g3services "github.com/quorumcontrol/messages/build/go/services"
 	"github.com/stretchr/testify/require"
+
+	"github.com/quorumcontrol/tupelo/gossip"
 )
 
 func TestConvertABR(t *testing.T) {
@@ -22,8 +24,9 @@ func TestConvertABR(t *testing.T) {
 	g4abr, err := ConvertABR(&g3abr)
 	require.Nil(t, err)
 
+	require.Equal(t, gossip.MagicValidNewTip, string(g4abr.NewTip))
+	
 	require.Equal(t, g3abr.State, g4abr.State)
-	require.Equal(t, g3abr.NewTip, g4abr.NewTip)
 	require.Equal(t, g3abr.Height, g4abr.Height)
 	require.Equal(t, g3abr.PreviousTip, g4abr.PreviousTip)
 	require.Equal(t, g3abr.ObjectId, g4abr.ObjectId)


### PR DESCRIPTION
Branch name is kind of misleading. There's nothing wrong with the gossip4 validator. Just needed to teach it how to ignore the `NewTip` property of converted gossip3 ABRs.