### PR TITLE
add tracing to snowballer, stop trace one wrapper for errors

### DIFF
--- a/gossip/sigverifier.go
+++ b/gossip/sigverifier.go
@@ -15,7 +15,7 @@ import (
 // This is used for verifying receiveToken transactions
 // TODO: we want receive tokens to use round paths through hamts intead of signatures
 func verifySignature(rootCtx context.Context, msg []byte, signature *signatures.Signature, verKeys []*bls.VerKey) (bool, error) {
-	sp, ctx := opentracing.StartSpanFromContext(rootCtx, "verifySignature")
+	sp, ctx := opentracing.StartSpanFromContext(rootCtx, "gossip4.verifySignature")
 	defer sp.Finish()
 
 	err := sigfuncs.RestoreBLSPublicKey(ctx, signature, verKeys)

--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -2,6 +2,7 @@ package gossip
 
 import (
 	"context"
+	"github.com/opentracing/opentracing-go"
 	"sync"
 	"time"
 
@@ -52,7 +53,11 @@ func (snb *snowballer) Started() bool {
 	return snb.started
 }
 
-func (snb *snowballer) start(ctx context.Context, done chan error) {
+func (snb *snowballer) start(startCtx context.Context, done chan error) {
+	sp := opentracing.StartSpan("snowballer.start")
+	defer sp.Finish()
+	ctx := opentracing.ContextWithSpan(startCtx, sp)
+
 	snb.Lock()
 	snb.started = true
 	snb.Unlock()

--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -54,7 +54,7 @@ func (snb *snowballer) Started() bool {
 }
 
 func (snb *snowballer) start(startCtx context.Context, done chan error) {
-	sp := opentracing.StartSpan("snowballer.start")
+	sp := opentracing.StartSpan("gossip4.snowballer.start")
 	defer sp.Finish()
 	ctx := opentracing.ContextWithSpan(startCtx, sp)
 


### PR DESCRIPTION
given the observability that we were missing for @cap10morgan , this adds a "stop tracing" to any errors coming in on the handleAddBlockRequest.

I also realized we weren't tracking any snowball runs, this adds the most basic "time how long a snowball takes" so at least we can see it running.