### PR TITLE
actually set the actor PID on start

### DIFF
--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -172,6 +172,8 @@ func (nb *NodeBuilder) startSigner(ctx context.Context) error {
 		return fmt.Errorf("error starting node: %v", err)
 	}
 
+	nb.signerActor = node.PID()
+
 	return nil
 }
 


### PR DESCRIPTION
this is my bad. @cap10morgan was seeing a nil PID on the g3->g4 subscriber and then I realized that we never actually set the PID here, so when the actor went to send the message, it was nil and errored.