### PR TITLE
Set EC2 public IP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.5-alpine3.10 AS build
+FROM golang:1.13.6-alpine3.11 AS build
 
 WORKDIR /app
 
@@ -8,10 +8,10 @@ COPY . .
 
 RUN go install -mod=vendor -v -a -gcflags=-trimpath="${PWD}" -asmflags=-trimpath="${PWD}"
 
-FROM alpine:3.10
+FROM alpine:3.11
 LABEL maintainer="dev@quorumcontrol.com"
 
-RUN apk add --no-cache --update gettext ca-certificates
+RUN apk add --no-cache --update gettext ca-certificates curl
 
 RUN mkdir -p /tupelo
 

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -21,6 +21,11 @@ if [ -n "$TUPELO_GOSSIP3_NOTARY_GROUP_URL" ]; then
   wget -q -O "$TUPELO_GOSSIP3_NOTARY_GROUP_CONFIG" "$TUPELO_GOSSIP3_NOTARY_GROUP_URL"
 fi
 
+if [ -n "$TUPELO_ADVERTISE_EC2_PUBLIC_IP" ]; then
+  TUPELO_PUBLIC_IP=$(curl -s http://169.254.169.254/latest/meta-data/public-ipv4)
+  export TUPELO_PUBLIC_IP
+fi
+
 if [ ! -f "$TUPELO_CONFIG_FILE" ]; then
   envsubst < /tupelo/config.toml.tpl  > "$TUPELO_CONFIG_FILE"
 fi

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/quorumcontrol/chaintree v0.9.4
 	github.com/quorumcontrol/messages v1.1.1
 	github.com/quorumcontrol/messages/v2 v2.1.2
-	github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200120142430-df0fb799984c
+	github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200122163552-2e47d54bc4d2
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -761,8 +761,8 @@ github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200111013635-908b6d63182
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200111013635-908b6d631822/go.mod h1:a0oCEBXbnQdnZQLL6gFmyXw7TBxpTKZILqLAXK7wcGg=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200111041028-c872b16c033b h1:6X0YBHQz+18SqWyDwo2MOc9cQNcklyV+wXHhNH6OG34=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200111041028-c872b16c033b/go.mod h1:eEl6oezYQDGnlM3Xfm6bFQJE4k/TjJC1f7nOGwhZHz0=
-github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200120142430-df0fb799984c h1:zvg1dMU6kyM530OIjv48hGJQJ0LkuQPIJqNTJJ8dEfI=
-github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200120142430-df0fb799984c/go.mod h1:yGMtIJDFSATAZTAwUvmhOgQd7qf0tGZbUgdQm/oGdKc=
+github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200122163552-2e47d54bc4d2 h1:Ru3W1epy7e7yzlCsnvaLW4EVs5p71C5pm5ei6Irg838=
+github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200122163552-2e47d54bc4d2/go.mod h1:yGMtIJDFSATAZTAwUvmhOgQd7qf0tGZbUgdQm/oGdKc=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=


### PR DESCRIPTION
About to deploy this to make sure it works. There will be an upcoming PR in tupelo-infrastructure to set `TUPELO_ADVERTISE_EC2_PUBLIC_IP` to `true`.

Has #392 in it too. Sorry about that.