### PR TITLE
set k to the size of the notary group if it is smaller than defaultK

### DIFF
--- a/gossip/node.go
+++ b/gossip/node.go
@@ -77,6 +77,13 @@ type NewNodeOptions struct {
 	RootActorContext *actor.RootContext // optional
 }
 
+func min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
 func NewNode(ctx context.Context, opts *NewNodeOptions) (*Node, error) {
 	hamtStore := hamtwrapper.DagStoreToCborIpld(opts.DagStore)
 
@@ -97,7 +104,7 @@ func NewNode(ctx context.Context, opts *NewNodeOptions) (*Node, error) {
 	// shouldn't be too hard, just save the latest round into a key/value store somewhere
 	// and then it can come back up and bootstrap itself up to the latest in the network
 	holder := newRoundHolder()
-	r := newRound(0)
+	r := newRound(0, 0, 0, min(defaultK, int(opts.NotaryGroup.Size())-1))
 	holder.SetCurrent(r)
 
 	n := &Node{
@@ -374,7 +381,7 @@ func (n *Node) handleSnowballerDone(msg *snowballerDone) {
 		n.logger.Errorf("error publishing current round: %v", err)
 	}
 
-	round := newRound(completedRound.height + 1)
+	round := newRound(completedRound.height+1, 0, 0, min(defaultK, int(n.notaryGroup.Size())-1))
 	n.rounds.SetCurrent(round)
 	n.snowballer = newSnowballer(n, round.height, round.snowball)
 }

--- a/gossip/rounds.go
+++ b/gossip/rounds.go
@@ -18,10 +18,22 @@ type round struct {
 	state    *hamt.Node
 }
 
-func newRound(height uint64) *round {
+func newRound(height uint64, alpha float64, beta int, k int) *round {
+	if alpha == 0.0 {
+		alpha = defaultAlpha
+	}
+
+	if beta == 0 {
+		beta = defaultBeta
+	}
+
+	if k == 0 {
+		k = defaultK
+	}
+
 	return &round{
 		height:   height,
-		snowball: NewSnowball(defaultAlpha, defaultBeta, defaultK),
+		snowball: NewSnowball(alpha, beta, k),
 	}
 }
 

--- a/gossip/rounds_test.go
+++ b/gossip/rounds_test.go
@@ -10,17 +10,17 @@ import (
 func TestRoundHolderSetCurrent(t *testing.T) {
 	rh := newRoundHolder()
 
-	rh.SetCurrent(newRound(0))
+	rh.SetCurrent(newRound(0, 0, 0, 0))
 	require.Equal(t, uint64(0), rh.Current().height)
 
-	rh.SetCurrent(newRound(1))
+	rh.SetCurrent(newRound(1, 0, 0, 0))
 	assert.Equal(t, uint64(1), rh.Current().height)
 }
 
 func TestRoundHolderGet(t *testing.T) {
 	rh := newRoundHolder()
 
-	r := newRound(0)
+	r := newRound(0, 0, 0, 0)
 	rh.SetCurrent(r)
 
 	returned, exists := rh.Get(0)


### PR DESCRIPTION
from chat:
```
still seeing here: 13:34:18.588 WARNI     node-3: error creating stream to 0x7D3299C2a7304Fd74074af30785724C79A775d42: dial backoff snowballnetwork.go:148
EDITED
and 13:34:18.587 DEBUG   snowball: tick len(votes): 2 snowball.go:58
hmm
13:34:18.587 DEBUG   snowball: calculateTallies: bafyreic5vbgrj4iwyctxqrjerszzew7ks4sflhrsnpkhyixfrvezbvkwvq vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: bafyreic5vbgrj4iwyctxqrjerszzew7ks4sflhrsnpkhyixfrvezbvkwvq vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: bafyreic5vbgrj4iwyctxqrjerszzew7ks4sflhrsnpkhyixfrvezbvkwvq vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: bafyreic5vbgrj4iwyctxqrjerszzew7ks4sflhrsnpkhyixfrvezbvkwvq vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: n vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: n vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: n vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: n vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: n vote.go:48
13:34:18.587 DEBUG   snowball: calculateTallies: n vote.go:48
13:34:18.587 DEBUG   snowball: tick len(votes): 2 snowball.go:58
i think that menas 4 votes came in and 6 failed, but that's a bit confusing because there are only 5 nodes
"n" means nil vote
i wonder if that's triggering the backoff
K should probably not be bigger than n-1 where n is number of signers
and right now it is
that's worth a quick try
```

I have a theory that hitting the same node over and over again in a single snowball tick is causing a dialbackoff. This sets k to notaryGroupSize -1 if that number is less than the default 10.