### PR TITLE
fix broken tx syncer and handle edge case in snowball

### DIFF
--- a/gossip/txsyncer.go
+++ b/gossip/txsyncer.go
@@ -15,18 +15,28 @@ type transactionGetter struct {
 	nodeActor *actor.PID
 	store     *hamt.CborIpldStore
 	logger    logging.EventLogger
+	validator *TransactionValidator
 }
 
 func (tg *transactionGetter) Receive(actorContext actor.Context) {
 	switch msg := actorContext.Message().(type) {
 	case cid.Cid:
-		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 		defer cancel()
 		abr := &services.AddBlockRequest{}
 		err := tg.store.Get(ctx, msg, abr)
 		if err != nil {
 			tg.logger.Warningf("error fetching %s", msg.String())
 		}
-		actorContext.Send(tg.nodeActor, abr)
+
+		valid := tg.validator.ValidateAbr(ctx, abr)
+		if valid {
+			wrapper := &AddBlockWrapper{
+				AddBlockRequest: abr,
+			}
+			wrapper.StartTrace("gossip4.syncer")
+			actorContext.Send(tg.nodeActor, wrapper)
+		}
+
 	}
 }


### PR DESCRIPTION
Big bug fixes:
* transaction syncer wasn't sending wrappers, so the abrs were being ignored (so no gossip fallback)
* transaction syncer wasn't validating txs

edge case:
If I'm sitting there with nothing in my mempool but someone comes and asks me to snowball then it's possible I'll never get out of my rut (because I missed Txs, but there's now way for me to get them).

This branch fixes that edge case by starting the snowball (without a preferred) if someone comes in  and asks me for a round and it's >= my current round (but I'm just sitting there). Then I'll start a snowball and ask the network what it thinks so I can sync up my missing Txs.