### PR TITLE
early committer

### DIFF
--- a/gossip/benchmark/benchmark_test.go
+++ b/gossip/benchmark/benchmark_test.go
@@ -118,6 +118,4 @@ func TestBenchmarker(t *testing.T) {
 	res := ben.Run(ctx)
 	require.InDelta(t, int64(1), res.Total, float64(1))
 	require.InDelta(t, 1, res.Measured, float64(1))
-
-	require.True(t, res.MaxDuration > 0)
 }

--- a/gossip/earlycommitter.go
+++ b/gossip/earlycommitter.go
@@ -1,0 +1,58 @@
+package gossip
+
+import (
+	"github.com/ipfs/go-cid"
+	"sync"
+)
+
+type signerIDToCheckpoint map[string]cid.Cid
+type signerList map[string]struct{}
+type checkpointVotes map[cid.Cid]signerList
+
+type earlyCommitter struct {
+	sync.RWMutex
+
+	currentSignerVotes signerIDToCheckpoint // map of signer id to
+	checkpointVotes    checkpointVotes      // map of checkpoint to a list of signers voting for it
+}
+
+func newEarlyCommitter() *earlyCommitter {
+	return &earlyCommitter{
+		currentSignerVotes: make(signerIDToCheckpoint),
+		checkpointVotes:    make(checkpointVotes),
+	}
+}
+
+func (ec *earlyCommitter) Vote(signerID string, checkpointID cid.Cid) {
+	ec.Lock()
+	defer ec.Unlock()
+
+	existing, ok := ec.currentSignerVotes[signerID]
+	if ok {
+		if existing == checkpointID {
+			return
+		}
+		delete(ec.checkpointVotes[existing], signerID)
+	}
+	ec.currentSignerVotes[signerID] = checkpointID
+
+	voteList, ok := ec.checkpointVotes[checkpointID]
+	if !ok {
+		voteList = make(signerList)
+	}
+	voteList[signerID] = struct{}{}
+	ec.checkpointVotes[checkpointID] = voteList
+}
+
+func (ec *earlyCommitter) HasThreshold(totalCount int, threshold float64) (bool, cid.Cid) {
+	ec.RLock()
+	defer ec.RUnlock()
+
+	total := float64(totalCount)
+	for checkpointID, list := range ec.checkpointVotes {
+		if float64(len(list))/total >= threshold {
+			return true, checkpointID
+		}
+	}
+	return false, cid.Undef
+}

--- a/gossip/earlycommitter.go
+++ b/gossip/earlycommitter.go
@@ -12,8 +12,8 @@ type checkpointVotes map[cid.Cid]signerList
 type earlyCommitter struct {
 	sync.RWMutex
 
-	currentSignerVotes signerIDToCheckpoint // map of signer id to
-	checkpointVotes    checkpointVotes      // map of checkpoint to a list of signers voting for it
+	currentSignerVotes signerIDToCheckpoint // map of signer id to its current vote (checkpoint CID)
+	checkpointVotes    checkpointVotes      // map of checkpointCID to a list of signers voting for it
 }
 
 func newEarlyCommitter() *earlyCommitter {

--- a/gossip/earlycommitter_test.go
+++ b/gossip/earlycommitter_test.go
@@ -1,0 +1,33 @@
+package gossip
+
+import (
+	"testing"
+
+	"github.com/quorumcontrol/chaintree/safewrap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEarlyCommit(t *testing.T) {
+	sw := &safewrap.SafeWrap{}
+
+	c1 := sw.WrapObject("1").Cid()
+	c2 := sw.WrapObject("2").Cid()
+	c3 := sw.WrapObject("3").Cid()
+
+	require.Nil(t, sw.Err)
+
+	ec := newEarlyCommitter()
+
+	ec.Vote("1", c1)
+	ec.Vote("2", c2)
+	ec.Vote("3", c3)
+	hasThreshold, _ := ec.HasThreshold(3, 0.66)
+	require.False(t, hasThreshold)
+
+	ec.Vote("2", c1)
+	hasThreshold, checkpoint := ec.HasThreshold(3, 0.66)
+
+	assert.True(t, hasThreshold)
+	assert.Truef(t, c1.Equals(checkpoint), "expected %s to equal %s", checkpoint.String(), c1.String())
+}

--- a/gossip/earlycommitter_test.go
+++ b/gossip/earlycommitter_test.go
@@ -27,7 +27,11 @@ func TestEarlyCommit(t *testing.T) {
 
 	ec.Vote("2", c1)
 	hasThreshold, checkpoint := ec.HasThreshold(3, 0.66)
-
 	assert.True(t, hasThreshold)
 	assert.Truef(t, c1.Equals(checkpoint), "expected %s to equal %s", checkpoint.String(), c1.String())
+
+	// checking the internals now, these can probably be deleted after this is stabilized
+	assert.Equal(t, c1, ec.currentSignerVotes["2"])
+	assert.Len(t, ec.checkpointVotes[c2], 0)
+	assert.Len(t, ec.checkpointVotes[c1], 2)
 }

--- a/gossip/mempool.go
+++ b/gossip/mempool.go
@@ -5,8 +5,11 @@ import (
 	"sync"
 
 	"github.com/ipfs/go-cid"
+	logging "github.com/ipfs/go-log"
 	"github.com/quorumcontrol/messages/v2/build/go/services"
 )
+
+var memlog = logging.Logger("mempool")
 
 type mempoolConflictSetID string
 type conflictSet struct {
@@ -52,6 +55,8 @@ func newMempool() *mempool {
 
 func (m *mempool) Add(id cid.Cid, abrWrapper *AddBlockWrapper) {
 	m.Lock()
+	memlog.Debugf("adding %s", id.String())
+
 	indexKey := toConflictSetID(abrWrapper.AddBlockRequest)
 	cs, ok := m.conflictSets[indexKey]
 	if !ok {
@@ -74,6 +79,7 @@ func (m *mempool) Get(id cid.Cid) *AddBlockWrapper {
 // conflicting ABRs as well.
 func (m *mempool) DeleteIDAndConflictSet(id cid.Cid) {
 	m.Lock()
+	memlog.Debugf("removing %s", id.String())
 	existing, ok := m.abrs[id]
 	if ok {
 		if existing.Started() {

--- a/gossip/node_test.go
+++ b/gossip/node_test.go
@@ -167,6 +167,9 @@ func TestEndToEnd(t *testing.T) {
 		abrs[i] = &abr
 	}
 
+	sub, err := nodes[0].pubsub.Subscribe(group.ID)
+	require.Nil(t, err)
+
 	for i, abr := range abrs {
 		bits, err := abr.Marshal()
 		require.Nil(t, err)
@@ -176,6 +179,13 @@ func TestEndToEnd(t *testing.T) {
 	}
 
 	waitForAllAbrs(t, ctx, nodes, abrs)
+
+	// test that it receives the round confirmation signatures
+	for range nodes {
+		_, err = sub.Next(ctx)
+		require.Nil(t, err)
+	}
+
 }
 
 func TestByzantineCases(t *testing.T) {

--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -82,9 +82,13 @@ func (snb *snowballer) start(startCtx context.Context, done chan error) {
 				done <- errors.New("could not find checkpoint in the cache: should never happen")
 				return
 			}
+			// TODO: this probably shouldn't reach into snowball here,
+			// maybe it could move decided logic up to the snowballer here and others could reference this
+			// rather than having the external system dig into the the snowball instance here too.
 			snb.snowball.Prefer(&Vote{
 				Checkpoint: checkpoint.(*types.Checkpoint),
 			})
+			snb.snowball.decided = true
 		}
 	}
 

--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -235,8 +235,6 @@ func (snb *snowballer) getOneRandomVote(parentCtx context.Context, wg *sync.Wait
 		snb.cache.Add(id, checkpoint)
 	}
 
-	snb.earlyCommitter.Vote(signerPeer, checkpoint.CID())
-
 	respChan <- &snowballVoteResp{
 		signerID:   signerPeer,
 		checkpoint: *checkpoint,

--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -121,7 +121,6 @@ func (snb *snowballer) doTick(startCtx context.Context) {
 	i := 0
 	for resp := range respChan {
 		checkpoint := resp.checkpoint
-		// snb.logger.Debugf("received checkpoint: %v", checkpoint)
 		vote := &Vote{
 			Checkpoint: &checkpoint,
 		}
@@ -136,6 +135,7 @@ func (snb *snowballer) doTick(startCtx context.Context) {
 		votes[i] = vote
 		// if the vote hasn't been nilled then we can add it to the early commiter
 		if vote.ID() != ZeroVoteID {
+			snb.logger.Debugf("received checkpoint: %v", checkpoint)
 			snb.earlyCommitter.Vote(resp.signerID, resp.checkpoint.CID())
 		}
 
@@ -258,6 +258,8 @@ func (snb *snowballer) mempoolHasAllABRs(abrCIDs []cid.Cid) bool {
 		if !ok {
 			snb.logger.Debugf("missing tx: %s", abrCID.String())
 			snb.node.rootContext.Send(snb.node.syncerPid, abrCID)
+			// the reason to not just return false here is that we want
+			// to continue to loop over all the Txs in order to sync the ones we don't have
 			hasAll = false
 		}
 	}

--- a/gossip/vote.go
+++ b/gossip/vote.go
@@ -12,6 +12,7 @@ type Vote struct {
 
 func (v *Vote) Nil() {
 	v.tallyCount = 0.0
+	v.Checkpoint = nil
 	v.id = ZeroVoteID
 }
 


### PR DESCRIPTION
This adds an early-commit gadget to snowball which says: if there is a checkpoint where > alpha of signers have voted for then the network will definitely consense there, so no need to do 150 rounds.

The way it works:

Every vote that comes in is registered in the earlyCommitter struct and every tick we look at that struct and see if there's a checkpoint that > alpha (currently 0.8) signers have voted for then we can commit. 

If a signer changes its vote, its vote is changed in the earlyCommitter too.