### PR TITLE
benchmark improvements

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -17,6 +17,7 @@ import (
 var benchmarkConcurrency int
 var benchmarkDuration int
 var benchmarkStartDelay int
+var benchmarkTimeout int
 
 // benchmark represents the shell command
 var benchmarkCmd = &cobra.Command{
@@ -60,7 +61,7 @@ var benchmarkCmd = &cobra.Command{
 		cli := client.New(group, pubsubwrapper.WrapLibp2p(p2pHost.GetPubSub()), peer)
 		cli.Start(ctx)
 
-		b := benchmark.NewBenchmark(cli, benchmarkConcurrency, time.Duration(benchmarkDuration)*time.Second)
+		b := benchmark.NewBenchmark(cli, benchmarkConcurrency, time.Duration(benchmarkDuration)*time.Second, time.Duration(benchmarkTimeout)*time.Second)
 
 		results := b.Run(ctx)
 
@@ -73,5 +74,6 @@ func init() {
 	rootCmd.AddCommand(benchmarkCmd)
 	benchmarkCmd.Flags().IntVarP(&benchmarkConcurrency, "concurrency", "c", 1, "how many transactions to execute at once")
 	benchmarkCmd.Flags().IntVarP(&benchmarkDuration, "duration", "d", 10, "how many seconds to run benchmark for")
+	benchmarkCmd.Flags().IntVarP(&benchmarkTimeout, "timeout", "t", 10, "how many seconds to timeout waiting for Txs to complete")
 	benchmarkCmd.Flags().IntVar(&benchmarkStartDelay, "delay", 0, "how many seconds to wait before kicking off the benchmark; useful if network needs to stabilize first")
 }

--- a/gossip/benchmark/benchmark_test.go
+++ b/gossip/benchmark/benchmark_test.go
@@ -112,12 +112,10 @@ func TestBenchmarker(t *testing.T) {
 	cli, err := newClient(ctx, group, bootAddrs)
 	require.Nil(t, err)
 
-	ben := NewBenchmark(cli, 1, 1*time.Second)
+	ben := NewBenchmark(cli, 3, 3*time.Second, 1*time.Second)
 	require.NotNil(t, ben)
 
 	res := ben.Run(ctx)
-	require.InDelta(t, int64(1), res.Total, float64(1))
-	require.InDelta(t, 1, res.Measured, float64(1))
-
-	require.True(t, res.MaxDuration > 0)
+	require.InDelta(t, int64(9), res.Total, float64(1))
+	require.InDelta(t, 9, res.Measured, float64(1))
 }


### PR DESCRIPTION
* allow setting the timeout
* wait for timeout after the duration to allow transactions to finish
* use the error string for the resultset