### PR TITLE
reduce alpha

### DIFF
--- a/gossip/rounds.go
+++ b/gossip/rounds.go
@@ -7,7 +7,7 @@ import (
 )
 
 const (
-	defaultAlpha = 0.8
+	defaultAlpha = 0.666
 	defaultBeta  = 150
 	defaultK     = 10
 )

--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -75,7 +75,7 @@ func (snb *snowballer) Start(ctx context.Context) {
 	snb.started = true
 
 	preferred := snb.node.mempool.Preferred()
-	snb.logger.Debugf("starting snowballer (height: %d) and preferring %v", snb.height, preferred)
+	snb.logger.Debugf("starting snowballer (a: %f, k: %d, b: %d) (height: %d) and preferring %v", snb.snowball.alpha, snb.snowball.k, snb.snowball.beta, snb.height, preferred)
 	if len(preferred) > 0 {
 		snb.snowball.Prefer(&Vote{
 			Checkpoint: &types.Checkpoint{

--- a/gossip/vote_test.go
+++ b/gossip/vote_test.go
@@ -151,7 +151,7 @@ func TestTick(t *testing.T) {
 		assert.Nil(t, snowball.Preferred())
 	})
 
-	t.Run("no decision in case of 20% empty votes", func(t *testing.T) {
+	t.Run("no decision in case of 33% empty votes", func(t *testing.T) {
 		snowball.Reset()
 
 		votes := make([]*Vote, 0, snowball.k)
@@ -174,7 +174,7 @@ func TestTick(t *testing.T) {
 		}
 
 		assert.False(t, snowball.Decided())
-		assert.Equal(t, _checkpoint.Wrapped().Cid().String(), snowball.Preferred().Checkpoint.Wrapped().Cid().String())
+		assert.Nil(t, snowball.Preferred())
 	})
 
 	t.Run("transactions num majority checkpoint wins", func(t *testing.T) {


### PR DESCRIPTION
Alpha at 0.8 only allows 20% of evil nodes. I'm lowering the threshold to account for 1/3 of the network being evil.

Also adds a bit of logging around snowball params.