### PR TITLE
Allow tupelo binary to bind to ports < 1024

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN go install -mod=vendor -v -a -gcflags=-trimpath="${PWD}" -asmflags=-trimpath
 FROM alpine:3.11
 LABEL maintainer="dev@quorumcontrol.com"
 
-RUN apk add --no-cache --update gettext ca-certificates curl
+RUN apk add --no-cache --update gettext ca-certificates curl libcap
 
 RUN mkdir -p /tupelo
 
@@ -21,6 +21,8 @@ RUN addgroup -g 1000 tupelo && \
     chgrp 0 /tupelo
 
 COPY --from=build /go/bin/tupelo /usr/bin/tupelo
+RUN setcap 'cap_net_bind_service=+ep' /usr/bin/tupelo
+
 COPY ./docker/docker-entrypoint.sh /usr/bin/docker-entrypoint
 RUN chmod +x /usr/bin/docker-entrypoint
 


### PR DESCRIPTION
This allows tupelo within the container to bind to ports less than 1024 - while you can typically port forward from a server's < 1024 port to a > 1024 port in docker, the golang autocert automatically binds to 443 with no option to overwrite. The alternate path would require rewriting the golang autocert listener manually and having directly bound to 443 seems reasonable, especially things like address introspection will use the docker port and not the forwarded port