### PR TITLE
Support WSS address broadcasting

### DIFF
--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ipfs/go-bitswap"
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p"
+	ma "github.com/multiformats/go-multiaddr"
 	"github.com/quorumcontrol/tupelo-go-sdk/p2p"
 
 	circuit "github.com/libp2p/go-libp2p-circuit"
@@ -24,6 +25,19 @@ import (
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/shibukawa/configdir"
 )
+
+const MULTIADDR_WSS_CODE = 0x01DE
+
+func init() {
+	// Code 0 means not yet registered
+	if ma.ProtocolWithCode(MULTIADDR_WSS_CODE).Code == 0 {
+		ma.AddProtocol(ma.Protocol{
+			Name:  "wss",
+			Code:  MULTIADDR_WSS_CODE,
+			VCode: ma.CodeToVarint(MULTIADDR_WSS_CODE),
+		})
+	}
+}
 
 var logger = logging.Logger("nodebuilder")
 

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -325,7 +325,7 @@ func (nb *NodeBuilder) defaultP2POptions(ctx context.Context) []p2p.Option {
 	}
 
 	if nb.Config.SecureWebSocketDomain != "" {
-		opts = append(opts, p2p.WithExternalAddr("/dns4/"+nb.Config.SecureWebSocketDomain+"/tcp/443/ws"))
+		opts = append(opts, p2p.WithExternalAddr("/dns4/"+nb.Config.SecureWebSocketDomain+"/tcp/443/wss"))
 	}
 
 	return opts


### PR DESCRIPTION
wasm uses the `wss` protocol, however, we were previously specifying only `ws` in the broadcast addrs.  Changing it to `wss` resulted in `go-multiaddr` erroring because the protocol is explicitly not registered since it can't be used in go. To solve that issue, this registers the wss protocol as specified https://github.com/multiformats/multiaddr/blob/master/protocols.csv#L26