### PR TITLE
measure round durations in benchmarker

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/dgraph-io/badger v1.6.0
 	github.com/ethereum/go-ethereum v1.9.3
 	github.com/gobuffalo/packr/v2 v2.5.1
+	github.com/gogo/protobuf v1.3.1
 	github.com/gorilla/mux v1.7.1
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/ipfs/go-bitswap v0.1.9-0.20191015150653-291b2674f1f1
@@ -40,6 +41,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72
+	google.golang.org/grpc v1.21.1
 )
 
 // These replaces come from: https://github.com/ipfs/go-ipfs/issues/6795#issuecomment-571165734

--- a/go.sum
+++ b/go.sum
@@ -762,6 +762,7 @@ github.com/quorumcontrol/tupelo v0.5.12-0.20200111030921-f3f3d3244de7/go.mod h1:
 github.com/quorumcontrol/tupelo v0.5.12-0.20200111205713-bdcd8177fb62/go.mod h1:bGIgsVWW3ISO4f0r2N/b44fJbe9RLQZ0BFVSHDazEB4=
 github.com/quorumcontrol/tupelo v0.5.12-0.20200123190536-540022241c70/go.mod h1:jg2mK/ZptRCKhH/EQ61UaBzZJ7N2dG1E84Vy7E1Aen4=
 github.com/quorumcontrol/tupelo v0.5.12-0.20200129144132-3be48615b2ec/go.mod h1:t0szRFOWJ03Mf8uCeqPWjdKrMVWjUNuMyKkDHIgVZ/M=
+github.com/quorumcontrol/tupelo v0.5.12-0.20200221201325-8ab78c654b0d/go.mod h1:/M6OXjIeV9HVHtE0t3TNrhK7OeFfzvx3F1kPMNMcerc=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1 h1:bkol/s6k1audTyo8GG7JJUAUtlo1I9BWsxb00AXr4Yw=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1/go.mod h1:wA31G/DE4bI+8rsWKGRlxOgtKjrk0nJjd1qgRTpiN0Q=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200107015105-2d3804ccc20c/go.mod h1:+WlZ8i77PW1SQ1oEZ700ooGuC3JOcxPiA5ij8PkKCqk=

--- a/gossip/benchmark/benchmark.go
+++ b/gossip/benchmark/benchmark.go
@@ -193,7 +193,7 @@ func (b *Benchmark) Run(ctx context.Context) *ResultSet {
 	resultSet.Rounds.calculateStats()
 
 	// Just empty this out so results are easier to read
-	resultSet.Rounds.Durations = []int{}
+	resultSet.Rounds.Durations = nil
 
 	return resultSet
 }


### PR DESCRIPTION
Just adds round tracking and measurement into the benchmarker.

I actually want to refactor this quickly tomorrow morning into two instances of `DurationSet` for the rounds / transactions, but wanted to get this open in case it was useful in debugging.

Depends on https://github.com/quorumcontrol/tupelo-go-sdk/pull/193