### PR TITLE
republish completed rounds when not snowballing (and tick refactor)

### DIFF
--- a/gossip/node.go
+++ b/gossip/node.go
@@ -209,9 +209,10 @@ func (n *Node) Start(ctx context.Context) error {
 		// this is handled by the snowball actor spun up in the node's root actor (see: Receive function)
 		checkSnowballTicker := time.NewTicker(200 * time.Millisecond)
 		republishTicker := time.NewTicker(500 * time.Millisecond)
+		ctxDone := ctx.Done()
 		for {
 			select {
-			case <-ctx.Done():
+			case <-ctxDone:
 				checkSnowballTicker.Stop()
 				republishTicker.Stop()
 				return

--- a/gossip/node.go
+++ b/gossip/node.go
@@ -237,7 +237,7 @@ func (n *Node) maybeRepublish(ctx context.Context) {
 	if round := n.rounds.Current(); round != nil {
 		previousRound, found := n.rounds.Get(round.height - 1)
 		if found && previousRound != nil {
-			n.logger.Debugf("republishing round: %d", round.height)
+			n.logger.Debugf("republishing round: %d", previousRound.height)
 			n.publishCompletedRound(ctx, previousRound)
 		}
 	}


### PR DESCRIPTION
I opted for the simple thing here rather than adding a chaintree heartbeat. I also didn't worry too much about cacheing the previous send, etc... just wanted to get something in there. What this does now is every 500ms republish the last round with signature, et all as long as the signer is idle.