### PR TITLE
Persist rounds

### DIFF
--- a/configs/localdocker/node0/config.toml
+++ b/configs/localdocker/node0/config.toml
@@ -3,3 +3,7 @@ NotaryGroupConfig = "../localdocker.toml"
 [PrivateKeySet]
 SignKeyHex = "0x4344e3372f1b790016ed86400611fab64d0bba91136518685a7ce34106f1c759"
 DestKeyHex = "0xc09363e85290020c132053f029f23988d4e35c521b0698312e0071f3e5d0e023"
+
+[Storage]
+Kind = "badger"
+Path = "/tupelo/data"

--- a/configs/localdocker/node1/config.toml
+++ b/configs/localdocker/node1/config.toml
@@ -1,6 +1,9 @@
 NotaryGroupConfig = "../localdocker.toml"
 
-
 [PrivateKeySet]
 SignKeyHex = "0x39a9b8ab3266811852b8b18d1fd0562ffc907f3ecba297c9b2a89f742d349dc9"
 DestKeyHex = "0xa1b8b9936d8072b1a16311aee414289a5f8070acff847588386738d6d686fc9b"
+
+[Storage]
+Kind = "badger"
+Path = "/tupelo/data"

--- a/configs/localdocker/node2/config.toml
+++ b/configs/localdocker/node2/config.toml
@@ -3,3 +3,7 @@ NotaryGroupConfig = "../localdocker.toml"
 [PrivateKeySet]
 SignKeyHex = "0x558a546adacea3d761741bf4a6415ef2eeb85bfa457036b59564fa88ee276cf5"
 DestKeyHex = "0x251b3227fc393f810846f170c1534c2787721a4385d4711d93321302bf023bab"
+
+[Storage]
+Kind = "badger"
+Path = "/tupelo/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
+      - ./.tmp/node0/data:/tupelo/data
     command: ["node", "--config", "/configs/node0/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
 
@@ -39,6 +40,7 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
+      - ./.tmp/node1/data:/tupelo/data
     command: ["node", "--config", "/configs/node1/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
   
@@ -48,6 +50,7 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
+      - ./.tmp/node2/data:/tupelo/data
     command: ["node", "--config", "/configs/node2/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dgraph-io/badger v1.6.0
 	github.com/ethereum/go-ethereum v1.9.3
 	github.com/gobuffalo/packr/v2 v2.5.1
-	github.com/gogo/protobuf v1.3.1
+	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/gorilla/mux v1.7.1
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/ipfs/go-bitswap v0.1.9-0.20191015150653-291b2674f1f1
@@ -41,7 +41,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72
-	google.golang.org/grpc v1.21.1
+	google.golang.org/grpc v1.21.1 // indirect
 )
 
 // These replaces come from: https://github.com/ipfs/go-ipfs/issues/6795#issuecomment-571165734

--- a/gossip/rounds.go
+++ b/gossip/rounds.go
@@ -1,15 +1,27 @@
 package gossip
 
 import (
+	"fmt"
+	"strconv"
+	"strings"
 	"sync"
 
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/ipfs/go-datastore"
+	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/opentracing/opentracing-go"
+	"github.com/quorumcontrol/chaintree/safewrap"
+	"github.com/quorumcontrol/messages/v2/build/go/gossip"
+	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
 )
 
 const (
 	defaultAlpha = 0.666
 	defaultBeta  = 5
 	defaultK     = 100
+
+	roundsKeyRoot   = "/Snowball/Rounds"
+	currentRoundKey = "/Snowball/CurrentRoundHeight"
 )
 
 type round struct {
@@ -47,33 +59,125 @@ func newRound(height uint64, alpha float64, beta int, k int) *round {
 
 type roundHolder struct {
 	sync.RWMutex
-	currentRound uint64
-	rounds       map[uint64]*round
+	currentHeight uint64
+	roundCache    *lru.Cache
+	store         datastore.Batching
 }
 
-func newRoundHolder() *roundHolder {
+func newRoundHolder(store datastore.Batching) *roundHolder {
+	currentRoundDSKey := datastore.NewKey(currentRoundKey)
+	currentRoundExists, err := store.Has(currentRoundDSKey)
+	if err != nil {
+		panic(fmt.Errorf("error checking for current round from datastore: %w", err))
+	}
+
+	cache, err := lru.New(64)
+
+	if !currentRoundExists {
+		return &roundHolder{
+			currentHeight: 0,
+			roundCache:    cache,
+			store:         store,
+		}
+	}
+
+	crBytes, err := store.Get(currentRoundDSKey)
+	if err != nil {
+		panic(fmt.Errorf("error getting current round height from datastore: %w", err))
+	}
+
+	var cr uint64
+	err = cbornode.DecodeInto(crBytes, &cr)
+	if err != nil {
+		panic(fmt.Errorf("error decoding current round: %w", err))
+	}
+
 	return &roundHolder{
-		rounds: make(map[uint64]*round),
+		currentHeight: cr,
+		roundCache:    cache,
+		store:         store,
 	}
 }
 
+func datastoreKeyForHeight(height uint64) datastore.Key {
+	keyStr := strings.Join([]string{roundsKeyRoot, strconv.FormatUint(height, 10)}, "/")
+	return datastore.NewKey(keyStr)
+}
+
 func (rh *roundHolder) Current() *round {
-	rh.RLock()
-	r := rh.rounds[rh.currentRound]
-	rh.RUnlock()
-	return r
+	rh.Lock()
+	defer rh.Unlock()
+
+	cr, _ := rh.get(rh.currentHeight)
+	return cr
 }
 
 func (rh *roundHolder) Get(height uint64) (*round, bool) {
 	rh.RLock()
-	r, ok := rh.rounds[height]
-	rh.RUnlock()
-	return r, ok
+	defer rh.RUnlock()
+
+	return rh.get(height)
+}
+
+// Only for use when already inside a read lock
+func (rh *roundHolder) get(height uint64) (*round, bool) {
+	uncastRound, ok := rh.roundCache.Get(rh.currentHeight)
+	if ok {
+		return uncastRound.(*round), true
+	}
+
+	key := datastoreKeyForHeight(height)
+
+	ok, err := rh.store.Has(key)
+	if err != nil {
+		panic(fmt.Errorf("failed to check datastore for key %s: %w", key, err))
+	}
+	if !ok {
+		return nil, ok
+	}
+
+	grBytes, err := rh.store.Get(key)
+	if err != nil {
+		panic(fmt.Errorf("failed to get value from datastore for key %s: %w", key, err))
+	}
+
+	var gr gossip.Round
+	err = cbornode.DecodeInto(grBytes, &gr)
+
+	// TODO: Do we need to persist / restore anything more than height?
+	//  Can likely simplify this further if not.
+	r := newRound(gr.Height, 0.0, 0, 0)
+	rh.roundCache.Add(height, r)
+	return r, true
 }
 
 func (rh *roundHolder) SetCurrent(r *round) {
 	rh.Lock()
-	rh.rounds[r.height] = r
-	rh.currentRound = r.height
-	rh.Unlock()
+	defer rh.Unlock()
+
+	gRound := &gossip.Round{
+		Height: r.height,
+	}
+
+	wrappedRound := types.WrapRound(gRound)
+	err := rh.store.Put(datastoreKeyForHeight(r.height), wrappedRound.Wrapped().RawData())
+	if err != nil {
+		panic(fmt.Errorf("unable to store current round: %w", err))
+	}
+
+	// Should this even be CBOR?
+	sw := safewrap.SafeWrap{}
+	wrappedHeight := sw.WrapObject(r.height)
+	if sw.Err != nil {
+		panic(fmt.Errorf("unable to wrap current height: %w", sw.Err))
+	}
+
+	err = rh.store.Put(datastore.NewKey(currentRoundKey), wrappedHeight.RawData())
+	if err != nil {
+		panic(fmt.Errorf("unable to store current height: %w", err))
+	}
+
+	rh.roundCache.Add(r.height, r)
+
+	rh.currentHeight = r.height
 }

--- a/gossip/rounds_test.go
+++ b/gossip/rounds_test.go
@@ -3,12 +3,14 @@ package gossip
 import (
 	"testing"
 
+	"github.com/ipfs/go-datastore"
+	dsync "github.com/ipfs/go-datastore/sync"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRoundHolderSetCurrent(t *testing.T) {
-	rh := newRoundHolder()
+	rh := newRoundHolder(dsync.MutexWrap(datastore.NewMapDatastore()))
 
 	rh.SetCurrent(newRound(0, 0, 0, 0))
 	require.Equal(t, uint64(0), rh.Current().height)
@@ -18,7 +20,7 @@ func TestRoundHolderSetCurrent(t *testing.T) {
 }
 
 func TestRoundHolderGet(t *testing.T) {
-	rh := newRoundHolder()
+	rh := newRoundHolder(dsync.MutexWrap(datastore.NewMapDatastore()))
 
 	r := newRound(0, 0, 0, 0)
 	rh.SetCurrent(r)

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -3,6 +3,7 @@ package nodebuilder
 import (
 	"crypto/ecdsa"
 
+	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/quorumcontrol/tupelo-go-sdk/bls"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
@@ -41,4 +42,5 @@ type Config struct {
 	BootstrapOnly bool
 
 	Blockstore blockstore.Blockstore
+	Datastore  datastore.Batching
 }

--- a/nodebuilder/humanconfig.go
+++ b/nodebuilder/humanconfig.go
@@ -135,8 +135,13 @@ func HumanConfigToConfig(hc HumanConfig) (*Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error converting to blockstore: %v", err)
 	}
-
 	c.Blockstore = bstore
+
+	dstore, err := hc.Storage.ToDatastore()
+	if err != nil {
+		return nil, fmt.Errorf("error converting to datastore: %v", err)
+	}
+	c.Datastore = dstore
 
 	return c, nil
 }

--- a/nodebuilder/humanstorage.go
+++ b/nodebuilder/humanstorage.go
@@ -58,16 +58,12 @@ func (hsc *HumanStorageConfig) ToDatastore() (datastore.Batching, error) {
 	return hsc.toDatastore("datastore")
 }
 
-func (hsc *HumanStorageConfig) toDatastoreForBlockstore() (datastore.Batching, error) {
-	return hsc.toDatastore("blockstore")
-}
-
 func (hsc *HumanStorageConfig) ToBlockstore() (blockstore.Blockstore, error) {
-	datastore, err := hsc.toDatastoreForBlockstore()
+	ds, err := hsc.toDatastore("blockstore")
 	if err != nil {
 		return nil, fmt.Errorf("error getting datastore: %v", err)
 	}
-	bs := blockstore.NewBlockstore(datastore)
+	bs := blockstore.NewBlockstore(ds)
 	bs = blockstore.NewIdStore(bs)
 
 	// use -1 to turn off the cache,

--- a/nodebuilder/humanstorage.go
+++ b/nodebuilder/humanstorage.go
@@ -3,6 +3,7 @@ package nodebuilder
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -38,12 +39,14 @@ type HumanStorageConfig struct {
 	RootDirectory  string
 }
 
-func (hsc *HumanStorageConfig) toDatastore() (datastore.Batching, error) {
+func (hsc *HumanStorageConfig) toDatastore(name string) (datastore.Batching, error) {
+	// name arg is currently only used by badger b/c it needs a lock on the
+	// directory it uses; so you can't create more than on at the same path
 	switch strings.ToLower(hsc.Kind) {
 	case "", "memory": // not-specified means memory
 		return dsync.MutexWrap(datastore.NewMapDatastore()), nil
 	case "badger":
-		return NewDefaultBadger(hsc.Path)
+		return NewDefaultBadger(path.Join(hsc.Path, name))
 	case "s3":
 		return NewS3(hsc)
 	default:
@@ -51,8 +54,16 @@ func (hsc *HumanStorageConfig) toDatastore() (datastore.Batching, error) {
 	}
 }
 
+func (hsc *HumanStorageConfig) ToDatastore() (datastore.Batching, error) {
+	return hsc.toDatastore("datastore")
+}
+
+func (hsc *HumanStorageConfig) toDatastoreForBlockstore() (datastore.Batching, error) {
+	return hsc.toDatastore("blockstore")
+}
+
 func (hsc *HumanStorageConfig) ToBlockstore() (blockstore.Blockstore, error) {
-	datastore, err := hsc.toDatastore()
+	datastore, err := hsc.toDatastoreForBlockstore()
 	if err != nil {
 		return nil, fmt.Errorf("error getting datastore: %v", err)
 	}

--- a/nodebuilder/humanstorage.go
+++ b/nodebuilder/humanstorage.go
@@ -41,7 +41,7 @@ type HumanStorageConfig struct {
 
 func (hsc *HumanStorageConfig) toDatastore(name string) (datastore.Batching, error) {
 	// name arg is currently only used by badger b/c it needs a lock on the
-	// directory it uses; so you can't create more than on at the same path
+	// directory it uses; so you can't create more than one at the same path
 	switch strings.ToLower(hsc.Kind) {
 	case "", "memory": // not-specified means memory
 		return dsync.MutexWrap(datastore.NewMapDatastore()), nil

--- a/nodebuilder/localnetwork.go
+++ b/nodebuilder/localnetwork.go
@@ -51,14 +51,24 @@ func NewLocalNetwork(ctx context.Context, namespace string, keys []*PrivateKeySe
 
 	configs := make([]*Config, len(signers))
 	for i, keySet := range keys {
-		hsc := &HumanStorageConfig{
+		hscBlock := &HumanStorageConfig{
 			Kind: "badger",
-			Path: path.Join(configDir(namespace, localConfigName), strconv.Itoa(i)),
+			Path: path.Join(configDir(namespace, localConfigName), strconv.Itoa(i), "block"),
 		}
 
-		bstore, err := hsc.ToBlockstore()
+		hscData := &HumanStorageConfig{
+			Kind: "badger",
+			Path: path.Join(configDir(namespace, localConfigName), strconv.Itoa(i), "data"),
+		}
+
+		bstore, err := hscBlock.ToBlockstore()
 		if err != nil {
 			return nil, fmt.Errorf("error setting up badger blockstore: %v", err)
+		}
+
+		dstore, err := hscData.ToDatastore()
+		if err != nil {
+			return nil, fmt.Errorf("error setting up badger datastore: %w", err)
 		}
 
 		configs[i] = &Config{
@@ -66,6 +76,7 @@ func NewLocalNetwork(ctx context.Context, namespace string, keys []*PrivateKeySe
 			PrivateKeySet:     keySet,
 			BootstrapNodes:    ln.BootstrapAddrrs,
 			Blockstore:        bstore,
+			Datastore:         dstore,
 		}
 	}
 

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -195,6 +195,7 @@ func (nb *NodeBuilder) startSigner(ctx context.Context) (*p2p.LibP2PHost, error)
 		SignKey:     localKeys.SignKey,
 		NotaryGroup: group,
 		DagStore:    bitswapper,
+		Datastore:   nb.Config.Datastore,
 	}
 
 	node, err := gossip.NewNode(ctx, nodeCfg)

--- a/nodebuilder/nodebuilder_test.go
+++ b/nodebuilder/nodebuilder_test.go
@@ -69,6 +69,9 @@ func TestSigner(t *testing.T) {
 		bstore, err := hsc.ToBlockstore()
 		require.Nil(t, err)
 
+		dstore, err := hsc.ToDatastore()
+		require.Nil(t, err)
+
 		nb := &NodeBuilder{
 			Config: &Config{
 				NotaryGroupConfig: ngConfig,
@@ -77,6 +80,7 @@ func TestSigner(t *testing.T) {
 					SignKey: ts.SignKeys[0],
 				},
 				Blockstore:     bstore,
+				Datastore:      dstore,
 				BootstrapNodes: addrs,
 			},
 		}


### PR DESCRIPTION
This isn't quite working yet (hence the draft) due to not everything being persisted / restored yet in the rounds. But I wanted to get this opened so others could weigh in on the overall direction and questions I added in a few comments.

The overall approach here is to make the configured datastore the DB of record for rounds with an LRU cache in memory (of arbitrary size 64 b/c 🤷‍♂) since all of our perf numbers thus far have been based on these being in memory. Then when a node comes up it looks in the datastore to see if there is a persisted current round and tries to restore that if so. If not it starts up more or less like it used to.

I think the biggest question is: What needs to be persisted / restored besides height? Something about the globalState perhaps?

I don't think we should block the g4 release on getting this done unless anyone has a much simpler version of it in mind.