### PR TITLE
allow longer timeouts and reset when done with a stream.

### DIFF
--- a/gossip/node.go
+++ b/gossip/node.go
@@ -466,7 +466,7 @@ func (n *Node) SnowBallReceive(actorContext actor.Context) {
 func (n *Node) handleStream(actorContext actor.Context, s network.Stream) {
 	defer s.Close()
 
-	if err := s.SetWriteDeadline(time.Now().Add(2 * time.Second)); err != nil {
+	if err := s.SetWriteDeadline(time.Now().Add(8 * time.Second)); err != nil {
 		n.logger.Errorf("error setting write deadline: %v", err)
 	}
 	if err := s.SetReadDeadline(time.Now().Add(1 * time.Second)); err != nil {
@@ -484,8 +484,6 @@ func (n *Node) handleStream(actorContext actor.Context, s network.Stream) {
 		n.logger.Warningf("error reading from incoming stream: %v", err)
 		return
 	}
-	//TODO: I don't actually know what this does :)
-	reader.ReleaseMsg(bits)
 
 	var height uint64
 	err = cbornode.DecodeInto(bits, &height)

--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -232,16 +232,16 @@ func (snb *snowballer) getOneRandomVote(parentCtx context.Context, tokenCh chan 
 		sp.LogKV("error", err.Error())
 		snb.logger.Warningf("error creating stream to %s: %v", signer.ID, err)
 		if s != nil {
-			s.Close()
+			s.Reset()
 		}
 		return
 	}
-	defer s.Close()
+	defer s.Reset()
 
 	sw := &safewrap.SafeWrap{}
 	wrapped := sw.WrapObject(snb.height)
 
-	if err := s.SetDeadline(time.Now().Add(2 * time.Second)); err != nil {
+	if err := s.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
 		sp.LogKV("error", err.Error())
 		snb.logger.Errorf("error setting deadline: %v", err) // TODO: do we need to do anything about this error?
 		return


### PR DESCRIPTION
running locally @ 300 TPS I was seeing similar behavior to what we see at remote. This change made 100% of the benchmarks finish with relatively OK times too.

With the new parallel stuff, these longer time outs aren't as bad because they hold up a worker and not a round.

```
"Total": 3530,
benchmark_1  |   "AverageDuration": 9846,
benchmark_1  |   "MinDuration": 2759,
benchmark_1  |   "MaxDuration": 15559,
benchmark_1  |   "P95Duration": 14834,
benchmark_1  |   "FirstRound": 0,
benchmark_1  |   "Rounds": {
benchmark_1  |     "Durations": null,
benchmark_1  |     "Total": 5,
benchmark_1  |     "AverageDuration": 5799,
benchmark_1  |     "MinDuration": 2535,
benchmark_1  |     "MaxDuration": 8447,
benchmark_1  |     "P95Duration": 8447
benchmark_1  |   },
```