### PR TITLE
Fix roundHolder mem leak and add full round history

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,9 +33,6 @@ $(call GUARD,VERSION):
 $(FIRSTGOPATH)/bin/packr2:
 	GO111MODULE=off go get -u github.com/gobuffalo/packr/v2/packr2
 
-$(FIRSTGOPATH)/bin/gotestsum:
-	GO111MODULE=off go get -u gotest.tools/gotestsum
-
 $(packr): $(FIRSTGOPATH)/bin/packr2 $(VERSION_TXT)
 	$(FIRSTGOPATH)/bin/packr2
 
@@ -52,8 +49,8 @@ lint: $(FIRSTGOPATH)/bin/golangci-lint $(packr)
 $(FIRSTGOPATH)/bin/golangci-lint:
 	./scripts/download-golangci-lint.sh
 
-test: $(packr) $(gosources) go.mod go.sum $(FIRSTGOPATH)/bin/gotestsum
-	$(FIRSTGOPATH)/bin/gotestsum -- -tags=integration ./...
+test: $(packr) $(gosources) go.mod go.sum
+	go test -tags=integration ./...
 
 docker-image: vendor $(packr) $(gosources) Dockerfile .dockerignore
 	docker build -t quorumcontrol/tupelo:$(TAG) .

--- a/configs/localdocker/node0/config.toml
+++ b/configs/localdocker/node0/config.toml
@@ -3,3 +3,7 @@ NotaryGroupConfig = "../localdocker.toml"
 [PrivateKeySet]
 SignKeyHex = "0x4344e3372f1b790016ed86400611fab64d0bba91136518685a7ce34106f1c759"
 DestKeyHex = "0xc09363e85290020c132053f029f23988d4e35c521b0698312e0071f3e5d0e023"
+
+[Storage]
+Kind = "badger"
+Path = "/tupelo/data"

--- a/configs/localdocker/node1/config.toml
+++ b/configs/localdocker/node1/config.toml
@@ -1,6 +1,9 @@
 NotaryGroupConfig = "../localdocker.toml"
 
-
 [PrivateKeySet]
 SignKeyHex = "0x39a9b8ab3266811852b8b18d1fd0562ffc907f3ecba297c9b2a89f742d349dc9"
 DestKeyHex = "0xa1b8b9936d8072b1a16311aee414289a5f8070acff847588386738d6d686fc9b"
+
+[Storage]
+Kind = "badger"
+Path = "/tupelo/data"

--- a/configs/localdocker/node2/config.toml
+++ b/configs/localdocker/node2/config.toml
@@ -3,3 +3,7 @@ NotaryGroupConfig = "../localdocker.toml"
 [PrivateKeySet]
 SignKeyHex = "0x558a546adacea3d761741bf4a6415ef2eeb85bfa457036b59564fa88ee276cf5"
 DestKeyHex = "0x251b3227fc393f810846f170c1534c2787721a4385d4711d93321302bf023bab"
+
+[Storage]
+Kind = "badger"
+Path = "/tupelo/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,7 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
+      - ./.tmp/node0/data:/tupelo/data
     command: ["node", "--config", "/configs/node0/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
 
@@ -39,6 +40,7 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
+      - ./.tmp/node1/data:/tupelo/data
     command: ["node", "--config", "/configs/node1/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
   
@@ -48,6 +50,7 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
+      - ./.tmp/node2/data:/tupelo/data
     command: ["node", "--config", "/configs/node2/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,6 @@ require (
 	github.com/dgraph-io/badger v1.6.0
 	github.com/ethereum/go-ethereum v1.9.3
 	github.com/gobuffalo/packr/v2 v2.5.1
-	github.com/gogo/protobuf v1.3.1
 	github.com/gorilla/mux v1.7.1
 	github.com/hashicorp/golang-lru v0.5.3
 	github.com/ipfs/go-bitswap v0.1.9-0.20191015150653-291b2674f1f1
@@ -41,7 +40,6 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20200204104054-c9f3fb736b72
-	google.golang.org/grpc v1.21.1
 )
 
 // These replaces come from: https://github.com/ipfs/go-ipfs/issues/6795#issuecomment-571165734

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,7 @@ github.com/aws/aws-sdk-go v1.28.4 h1:LMGtba0y+VeepMzjz1HLie6bcgvZd7mLDxY1axBeFq8
 github.com/aws/aws-sdk-go v1.28.4/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
+github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bifurcation/mint v0.0.0-20181105073638-824af6541065/go.mod h1:zVt7zX3K/aDCk9Tj+VM7YymsX66ERvzCJzw8rFCX2JU=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
@@ -108,6 +109,7 @@ github.com/ethereum/go-ethereum v1.9.3 h1:v3bE4abkXknLcyWCf4TRFn+Ecmm9thPtfLFvTE
 github.com/ethereum/go-ethereum v1.9.3/go.mod h1:PwpWDrCLZrV+tfrhqqF6kPknbISMHaJv9Ln3kPCZLwY=
 github.com/facebookgo/atomicfile v0.0.0-20151019160806-2de1f203e7d5/go.mod h1:JpoxHjuQauoxiFMl1ie8Xc/7TfLuMZ5eOCONd1sUBHg=
 github.com/fatih/color v1.6.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
+github.com/fatih/color v1.7.0 h1:DkWD4oS2D8LGGgTQ6IvwJJXSL5Vp2ffcQg58nFV38Ys=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fd/go-nat v1.0.0/go.mod h1:BTBu/CKvMmOMUPkKVef1pngt2WFH/lg7E6yQnulfp6E=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
@@ -203,14 +205,18 @@ github.com/gxed/go-shellwords v1.0.3/go.mod h1:N7paucT91ByIjmVJHhvoarjoQnmsi3Jd3
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/gxed/pubsub v0.0.0-20180201040156-26ebdf44f824/go.mod h1:OiEWyHgK+CWrmOlVquHaIK1vhpUJydC9m0Je6mhaiNE=
+github.com/hashicorp/consul v1.4.2 h1:D9iJoJb8Ehe/Zmr+UEE3U3FjOLZ4LUxqFMl4O43BM1U=
 github.com/hashicorp/consul v1.4.2/go.mod h1:mFrjN1mfidgJfYP1xrJCF+AfRhr6Eaqhb2+sfyn/OOI=
+github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
+github.com/hashicorp/go-multierror v1.0.0 h1:iVjPR7a6H0tWELX5NxNe7bYopibicUzc7uPribsnS6o=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
+github.com/hashicorp/go-syslog v1.0.0 h1:KaodqZuhUoZereWVIYmpUgZysurB1kBLX2j0MwMrUAE=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
 github.com/hashicorp/go-uuid v1.0.0/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
@@ -221,6 +227,7 @@ github.com/hashicorp/golang-lru v0.5.3 h1:YPkqC67at8FYaadspW/6uE0COsBxS2656RLEr8
 github.com/hashicorp/golang-lru v0.5.3/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl v0.0.0-20180404174102-ef8a98b0bbce/go.mod h1:oZtUIOe8dh44I2q6ScRibXws4Ajl+d+nod3AaR9vL5w=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
+github.com/hashicorp/logutils v1.0.0 h1:dLEQVugN8vlakKOUE3ihGLTZJRB4j+M2cdTm/ORI65Y=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
@@ -647,6 +654,7 @@ github.com/minio/sha256-simd v0.1.0/go.mod h1:2FMWW+8GMoPweT6+pI63m9YE3Lmw4J71hV
 github.com/minio/sha256-simd v0.1.1-0.20190913151208-6de447530771/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/sha256-simd v0.1.1 h1:5QHSlgo3nt5yKOJrC7W8w7X+NFl8cMPZm96iu8kKUJU=
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
+github.com/mitchellh/cli v1.0.0 h1:iGBIsUe3+HZ/AD/Vd7DErOt5sU9fa8Uj7A2s1aggv1Y=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
@@ -722,6 +730,7 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/polydawn/refmt v0.0.0-20190221155625-df39d6c2d992/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
 github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1 h1:CskT+S6Ay54OwxBGB0R3Rsx4Muto6UnEYTyKJbyRIAI=
 github.com/polydawn/refmt v0.0.0-20190807091052-3d65705ee9f1/go.mod h1:uIp+gprXxxrWSjjklXD+mN4wed/tMfjMMmN/9+JsA9o=
+github.com/posener/complete v1.1.1 h1:ccV59UEOTzVDnDUEFdT95ZzHVZ+5+158q8+SJb2QV5w=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
@@ -762,7 +771,6 @@ github.com/quorumcontrol/tupelo v0.5.12-0.20200111030921-f3f3d3244de7/go.mod h1:
 github.com/quorumcontrol/tupelo v0.5.12-0.20200111205713-bdcd8177fb62/go.mod h1:bGIgsVWW3ISO4f0r2N/b44fJbe9RLQZ0BFVSHDazEB4=
 github.com/quorumcontrol/tupelo v0.5.12-0.20200123190536-540022241c70/go.mod h1:jg2mK/ZptRCKhH/EQ61UaBzZJ7N2dG1E84Vy7E1Aen4=
 github.com/quorumcontrol/tupelo v0.5.12-0.20200129144132-3be48615b2ec/go.mod h1:t0szRFOWJ03Mf8uCeqPWjdKrMVWjUNuMyKkDHIgVZ/M=
-github.com/quorumcontrol/tupelo v0.5.12-0.20200221201325-8ab78c654b0d/go.mod h1:/M6OXjIeV9HVHtE0t3TNrhK7OeFfzvx3F1kPMNMcerc=
 github.com/quorumcontrol/tupelo v0.5.12-0.20200226160350-8bc73f1e0652/go.mod h1:3+5xLTaAH0ldclLgxAVCkIMFRWqJH6AKKfbsY3NegTQ=
 github.com/quorumcontrol/tupelo v0.5.12-0.20200228085742-a503ff3ef25f/go.mod h1:oMcb9mVNuttvYUE/enVBrdAYKZ9uV+vxTSRoVrDewFg=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1 h1:bkol/s6k1audTyo8GG7JJUAUtlo1I9BWsxb00AXr4Yw=
@@ -780,8 +788,6 @@ github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200129114839-0d0c6bc84fd
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200129114839-0d0c6bc84fd3/go.mod h1:gix9XW6TZ1G9KieMw1aat2G9rAjBEtsaYb0pC818rFU=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200226084025-d1ef23ea82c2 h1:79TU81ITP+Uay9LWvyJQLmDcsmiyLn/uFq4L+IPVUig=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200226084025-d1ef23ea82c2/go.mod h1:FacTufzYlDnWnhChtBvOi2yix8bbYOs37/0m53zKuN0=
-github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200227160707-21c1f31e9a25 h1:TgQ0fQMd2kuLv1pEl9Uvhk6UcnldK1iITGQ81JRgXUI=
-github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200227160707-21c1f31e9a25/go.mod h1:0fDHOrkzj1T5VDMjh4K3Y1btiRRevBl/zMPuDAf3ZDg=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200227184332-a1d02e8ba5f0 h1:o9eHr3t3dX3jCWNuYHwqQvBUCqoDilSF1++u0uRlZnk=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200227184332-a1d02e8ba5f0/go.mod h1:0fDHOrkzj1T5VDMjh4K3Y1btiRRevBl/zMPuDAf3ZDg=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200228230624-c8f942c4e131 h1:5x1t8Zwm6UmWQ35t36K0O1HNBdOCAB097A6W3j0miis=

--- a/gossip/benchmark/benchmark_test.go
+++ b/gossip/benchmark/benchmark_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/ipfs/go-bitswap"
+	"github.com/ipfs/go-datastore"
+	dsync "github.com/ipfs/go-datastore/sync"
 	logging "github.com/ipfs/go-log"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
@@ -18,7 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTupeloSystem(ctx context.Context, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*gossip.Node, error) {
+func newTupeloSystem(ctx context.Context, t testing.TB, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*gossip.Node) {
 	nodes := make([]*gossip.Node, len(testSet.SignKeys))
 
 	ng := types.NewNotaryGroup("testnotary")
@@ -30,31 +32,29 @@ func newTupeloSystem(ctx context.Context, testSet *testnotarygroup.TestSet) (*ty
 
 	for i := range ng.AllSigners() {
 		p2pNode, peer, err := p2p.NewHostAndBitSwapPeer(ctx, p2p.WithKey(testSet.EcdsaKeys[i]), p2p.WithBitswapOptions(bitswap.ProvideEnabled(false)))
-		if err != nil {
-			return nil, nil, fmt.Errorf("error making node: %v", err)
-		}
+		require.Nil(t, err)
+
+		dataStore := dsync.MutexWrap(datastore.NewMapDatastore())
 
 		n, err := gossip.NewNode(ctx, &gossip.NewNodeOptions{
 			P2PNode:     p2pNode,
 			SignKey:     testSet.SignKeys[i],
 			NotaryGroup: ng,
 			DagStore:    peer,
+			Datastore:   dataStore,
 		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("error making node: %v", err)
-		}
+		require.Nil(t, err)
 		nodes[i] = n
 	}
 	// setting log level to debug because it's useful output on test failures
 	// this happens after the AllSigners loop because the node name is based on the
 	// index in the signers
 	for i := range ng.AllSigners() {
-		if err := logging.SetLogLevel(fmt.Sprintf("node-%d", i), "debug"); err != nil {
-			return nil, nil, fmt.Errorf("error setting log level: %v", err)
-		}
+		err := logging.SetLogLevel(fmt.Sprintf("node-%d", i), "debug")
+		require.Nil(t, err)
 	}
 
-	return ng, nodes, nil
+	return ng, nodes
 }
 
 func startNodes(t *testing.T, ctx context.Context, nodes []*gossip.Node, bootAddrs []string) {
@@ -97,8 +97,7 @@ func TestBenchmarker(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	group, nodes, err := newTupeloSystem(ctx, ts)
-	require.Nil(t, err)
+	group, nodes := newTupeloSystem(ctx, t, ts)
 	require.Len(t, nodes, numMembers)
 
 	booter, err := p2p.NewHostFromOptions(ctx)

--- a/gossip/node.go
+++ b/gossip/node.go
@@ -3,6 +3,7 @@ package gossip
 import (
 	"bytes"
 	"context"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"strconv"
@@ -11,17 +12,15 @@ import (
 
 	"github.com/AsynkronIT/protoactor-go/actor"
 	lru "github.com/hashicorp/golang-lru"
+	"github.com/ipfs/go-cid"
 	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-hamt-ipld"
 	cbornode "github.com/ipfs/go-ipld-cbor"
+	logging "github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p-core/network"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	"github.com/libp2p/go-msgio"
 	"github.com/opentracing/opentracing-go"
-	"github.com/quorumcontrol/chaintree/safewrap"
-
-	"github.com/ipfs/go-cid"
-	"github.com/ipfs/go-hamt-ipld"
-	logging "github.com/ipfs/go-log"
-	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/quorumcontrol/chaintree/nodestore"
 	"github.com/quorumcontrol/messages/v2/build/go/gossip"
 	"github.com/quorumcontrol/messages/v2/build/go/services"
@@ -179,9 +178,10 @@ func (n *Node) initRoundHolder() error {
 	if err == datastore.ErrNotFound {
 		height = uint64(0)
 	} else {
-		err = cbornode.DecodeInto(heightBytes, height)
-		if err != nil {
-			return fmt.Errorf("could not decode last completed round height: %w", err)
+		var n int
+		height, n = binary.Uvarint(heightBytes)
+		if n <= 0 {
+			return fmt.Errorf("could not decode last completed round height")
 		}
 
 		height += 1
@@ -424,15 +424,11 @@ func (n *Node) publishCompletedRound(ctx context.Context, round *round) error {
 }
 
 func (n *Node) storeCompletedRound(round *types.RoundWrapper) error {
-	sw := safewrap.SafeWrap{}
-	wrappedHeight := sw.WrapObject(round.Height())
-	if sw.Err != nil {
-		return fmt.Errorf("could not wrap round height: %w", sw.Err)
-	}
-
-	err := n.dataStore.Put(datastore.NewKey(lastCompletedHeightKey), wrappedHeight.RawData())
+	heightBytes := make([]byte, binary.MaxVarintLen64)
+	binary.PutUvarint(heightBytes, round.Height())
+	err := n.dataStore.Put(datastore.NewKey(lastCompletedHeightKey), heightBytes)
 	if err != nil {
-		return fmt.Errorf("error storing completed round height: %w", err)
+		return fmt.Errorf("error storing completed round: %w", err)
 	}
 
 	key := roundKey(round.Height())

--- a/gossip/node.go
+++ b/gossip/node.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
@@ -13,11 +14,12 @@ import (
 	"github.com/ipfs/go-datastore"
 	cbornode "github.com/ipfs/go-ipld-cbor"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
-	msgio "github.com/libp2p/go-msgio"
+	"github.com/libp2p/go-msgio"
 	"github.com/opentracing/opentracing-go"
+	"github.com/quorumcontrol/chaintree/safewrap"
 
-	cid "github.com/ipfs/go-cid"
-	hamt "github.com/ipfs/go-hamt-ipld"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-hamt-ipld"
 	logging "github.com/ipfs/go-log"
 	"github.com/libp2p/go-libp2p-core/network"
 	"github.com/quorumcontrol/chaintree/nodestore"
@@ -31,7 +33,8 @@ import (
 )
 
 const gossipProtocol = "tupelo/v0.0.1"
-const lastCompletedRoundCIDKey = "/Snowball/LastCompletedRound"
+const lastCompletedHeightKey = "/Snowball/LastCompletedHeight"
+const completedRoundsKeyRoot = "/Snowball/CompletedRounds"
 
 type startSnowball struct {
 	ctx context.Context
@@ -90,6 +93,12 @@ func min(x, y int) int {
 	return y
 }
 
+func roundKey(height uint64) datastore.Key {
+	heightStr := strconv.FormatUint(height, 10)
+	keyStr := strings.Join([]string{completedRoundsKeyRoot, heightStr}, "/")
+	return datastore.NewKey(keyStr)
+}
+
 func NewNode(ctx context.Context, opts *NewNodeOptions) (*Node, error) {
 	hamtStore := hamtwrapper.DagStoreToCborIpld(opts.DagStore)
 
@@ -116,63 +125,6 @@ func NewNode(ctx context.Context, opts *NewNodeOptions) (*Node, error) {
 
 	dataStore := opts.Datastore
 	dagStore := opts.DagStore
-	roundCIDBytes, err := dataStore.Get(datastore.NewKey(lastCompletedRoundCIDKey))
-	if err != nil && err != datastore.ErrNotFound {
-		return nil, fmt.Errorf("could not look up last completed round: %w", err)
-	}
-
-	holder := newRoundHolder()
-	var height uint64
-	if err == datastore.ErrNotFound {
-		height = uint64(0)
-	} else {
-		roundCID, err := cid.Cast(roundCIDBytes)
-		if err != nil {
-			return nil, fmt.Errorf("could not cast to CID: %w", err)
-		}
-		roundNode, err := dagStore.Get(ctx, roundCID)
-		if err != nil {
-			return nil, fmt.Errorf("could not get last completed round from DAG store: %w", err)
-		}
-
-		var gr gossip.Round
-		err = cbornode.DecodeInto(roundNode.RawData(), &gr)
-		if err != nil {
-			return nil, fmt.Errorf("could not decode round: %w", err)
-		}
-
-		rw := types.WrapRound(&gr)
-		rw.SetStore(dagStore)
-
-		cp, err := rw.FetchCheckpoint(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not fetch checkpoint from completed round: %w", err)
-		}
-
-		gs := newGlobalState(hamtStore)
-		h, err := rw.FetchHamt(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not fetch HAMT: %w", err)
-		}
-		gs.hamt = h
-
-		r := &round{
-			height: gr.Height,
-			snowball: &Snowball{
-				preferred: &Vote{
-					Checkpoint: cp,
-				},
-			},
-			state: gs,
-		}
-
-		holder = holder.WithCompletedRounds(r)
-		height = r.height + 1
-	}
-	r := newRound(height, 0, 0, min(defaultK, int(opts.NotaryGroup.Size())-1))
-	logger.Infof("initializing snowball at height: %d with alpha: %f, beta: %d, and k: %d",
-		r.height, r.snowball.alpha, r.snowball.beta, r.snowball.k)
-	holder.SetCurrent(r)
 
 	n := &Node{
 		name:        nodeName,
@@ -182,7 +134,6 @@ func NewNode(ctx context.Context, opts *NewNodeOptions) (*Node, error) {
 		dagStore:    dagStore,
 		hamtStore:   hamtStore,
 		dataStore:   dataStore,
-		rounds:      holder,
 		signerIndex: signerIndex,
 		inflight:    cache,
 		mempool:     newMempool(),
@@ -190,17 +141,114 @@ func NewNode(ctx context.Context, opts *NewNodeOptions) (*Node, error) {
 		logger:      logger,
 	}
 
+	err = n.initRoundHolder(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not init roundHolder: %w", err)
+	}
+
 	if n.rootContext == nil {
 		n.rootContext = actor.EmptyRootContext
 	}
 
-
+	r := n.rounds.Current()
 	networkedSnowball := newSnowballer(n, r.height, r.snowball)
 	n.snowballer = networkedSnowball
 
 	n.stateStorer = newStateStorer(logger, n.dagStore)
 
 	return n, nil
+}
+
+func (n *Node) restoreRound(ctx context.Context, height uint64) (*round, error) {
+	key := roundKey(height)
+	roundCIDBytes, err := n.dataStore.Get(key)
+	if err != nil {
+		return nil, fmt.Errorf("could not look up round for height %d: %w", height, err)
+	}
+
+	roundCID, err := cid.Cast(roundCIDBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not cast to CID: %w", err)
+	}
+
+	roundNode, err := n.dagStore.Get(ctx, roundCID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get last completed round from DAG store: %w", err)
+	}
+
+	var gr gossip.Round
+	err = cbornode.DecodeInto(roundNode.RawData(), &gr)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode round: %w", err)
+	}
+
+	rw := types.WrapRound(&gr)
+	rw.SetStore(n.dagStore)
+
+	cp, err := rw.FetchCheckpoint(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch checkpoint from completed round: %w", err)
+	}
+
+	gs := newGlobalState(n.hamtStore)
+	h, err := rw.FetchHamt(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch HAMT: %w", err)
+	}
+	gs.hamt = h
+
+	r := &round{
+		height: gr.Height,
+		snowball: &Snowball{
+			preferred: &Vote{
+				Checkpoint: cp,
+			},
+		},
+		state: gs,
+	}
+
+	return r, nil
+}
+
+func (n *Node) initRoundHolder(ctx context.Context) error {
+	heightBytes, err := n.dataStore.Get(datastore.NewKey(lastCompletedHeightKey))
+	if err != nil && err != datastore.ErrNotFound {
+		return fmt.Errorf("could not look up last completed round: %w", err)
+	}
+
+	holder := newRoundHolder()
+
+	var height uint64
+	if err == datastore.ErrNotFound {
+		height = uint64(0)
+	} else {
+		err = cbornode.DecodeInto(heightBytes, height)
+		if err != nil {
+			return fmt.Errorf("could not decode last completed round height: %w", err)
+		}
+
+		rounds := make([]*round, height)
+		for h := height; h > 0; h-- {
+			round, err := n.restoreRound(ctx, h)
+			if err != nil {
+				return fmt.Errorf("could not restore round: %w", err)
+			}
+			rounds[h] = round
+		}
+
+		holder = holder.WithCompletedRounds(rounds...)
+		height += 1
+	}
+
+	r := newRound(height, 0, 0, min(defaultK, int(n.notaryGroup.Size())-1))
+	holder.SetCurrent(r)
+
+	n.logger.Infof("initializing snowball at height: %d with alpha: %f, beta: %d, and k: %d",
+		r.height, r.snowball.alpha, r.snowball.beta, r.snowball.k)
+
+	n.rounds = holder
+
+	return nil
 }
 
 func (n *Node) Start(ctx context.Context) error {
@@ -413,9 +461,9 @@ func (n *Node) publishCompletedRound(ctx context.Context, round *round) error {
 		return fmt.Errorf("error adding to dag store: %w", err)
 	}
 
-	err = n.dataStore.Put(datastore.NewKey(lastCompletedRoundCIDKey), wrappedCompletedRound.CID().Bytes())
+	err = n.storeCompletedRound(wrappedCompletedRound)
 	if err != nil {
-		return fmt.Errorf("error storing completed round CID: %w", err)
+		return fmt.Errorf("could not store completed round CID: %w", err)
 	}
 
 	conf, err := n.confirmCompletedRound(ctx, wrappedCompletedRound)
@@ -426,6 +474,27 @@ func (n *Node) publishCompletedRound(ctx context.Context, round *round) error {
 	n.logger.Debugf("publishing round confirmed to: %s", n.notaryGroup.ID)
 
 	return n.pubsub.Publish(n.notaryGroup.ID, conf.Data())
+}
+
+func (n *Node) storeCompletedRound(round *types.RoundWrapper) error {
+	sw := safewrap.SafeWrap{}
+	wrappedHeight := sw.WrapObject(round.Height())
+	if sw.Err != nil {
+		return fmt.Errorf("could not wrap round height: %w", sw.Err)
+	}
+
+	err := n.dataStore.Put(datastore.NewKey(lastCompletedHeightKey), wrappedHeight.RawData())
+	if err != nil {
+		return fmt.Errorf("error storing completed round height: %w", err)
+	}
+
+	key := roundKey(round.Height())
+	err = n.dataStore.Put(key, round.CID().Bytes())
+	if err != nil {
+		return fmt.Errorf("error storing round: %w", err)
+	}
+
+	return nil
 }
 
 func (n *Node) handleSnowballerDone(actorContext actor.Context, msg *snowballerDone) {

--- a/gossip/node_test.go
+++ b/gossip/node_test.go
@@ -2,7 +2,6 @@ package gossip
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 	"testing"
 	"time"
@@ -10,6 +9,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ipfs/go-bitswap"
+	"github.com/ipfs/go-datastore"
+	dsync "github.com/ipfs/go-datastore/sync"
 
 	"github.com/AsynkronIT/protoactor-go/actor"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/hamtwrapper"
@@ -24,10 +25,11 @@ import (
 
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/testhelpers"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
+
 	"github.com/quorumcontrol/tupelo/testnotarygroup"
 )
 
-func newTupeloSystem(ctx context.Context, t testing.TB, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*Node, error) {
+func newTupeloSystem(ctx context.Context, t testing.TB, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*Node) {
 	name := t.Name()
 	nodes := make([]*Node, len(testSet.SignKeys))
 
@@ -40,24 +42,23 @@ func newTupeloSystem(ctx context.Context, t testing.TB, testSet *testnotarygroup
 
 	for i := range ng.AllSigners() {
 		p2pNode, peer, err := p2p.NewHostAndBitSwapPeer(ctx, p2p.WithKey(testSet.EcdsaKeys[i]), p2p.WithBitswapOptions(bitswap.ProvideEnabled(false)))
-		if err != nil {
-			return nil, nil, fmt.Errorf("error making node: %v", err)
-		}
+		require.Nil(t, err)
+
+		dataStore := dsync.MutexWrap(datastore.NewMapDatastore())
 
 		n, err := NewNode(ctx, &NewNodeOptions{
 			P2PNode:     p2pNode,
 			SignKey:     testSet.SignKeys[i],
 			NotaryGroup: ng,
 			DagStore:    peer,
+			Datastore:   dataStore,
 			Name:        strconv.Itoa(i) + "-" + name,
 		})
-		if err != nil {
-			return nil, nil, fmt.Errorf("error making node: %v", err)
-		}
+		require.Nil(t, err)
 		nodes[i] = n
 	}
 
-	return ng, nodes, nil
+	return ng, nodes
 }
 
 func startNodes(t *testing.T, ctx context.Context, nodes []*Node) {
@@ -126,11 +127,10 @@ func TestNewNode(t *testing.T) {
 
 	numMembers := 1
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	_, nodes, err := newTupeloSystem(ctx, t, ts)
-	require.Nil(t, err)
+	_, nodes := newTupeloSystem(ctx, t, ts)
 	require.Len(t, nodes, numMembers)
 	n := nodes[0]
-	err = n.Start(ctx)
+	err := n.Start(ctx)
 	require.Nil(t, err)
 
 	abr, err := n.getCurrent(ctx, "no way")
@@ -144,8 +144,7 @@ func TestEndToEnd(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	group, nodes, err := newTupeloSystem(ctx, t, ts)
-	require.Nil(t, err)
+	group, nodes := newTupeloSystem(ctx, t, ts)
 	require.Len(t, nodes, numMembers)
 
 	startNodes(t, ctx, nodes)
@@ -192,8 +191,7 @@ func TestIdleRoundsRepublish(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	group, nodes, err := newTupeloSystem(ctx, t, ts)
-	require.Nil(t, err)
+	group, nodes := newTupeloSystem(ctx, t, ts)
 	require.Len(t, nodes, numMembers)
 
 	startNodes(t, ctx, nodes)
@@ -238,8 +236,7 @@ func TestByzantineCases(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	group, nodes, err := newTupeloSystem(ctx, t, ts)
-	require.Nil(t, err)
+	group, nodes := newTupeloSystem(ctx, t, ts)
 	require.Len(t, nodes, numMembers)
 
 	startNodes(t, ctx, nodes)

--- a/gossip/rounds.go
+++ b/gossip/rounds.go
@@ -1,9 +1,19 @@
 package gossip
 
 import (
+	"context"
+	"fmt"
 	"sync"
 
+	lru "github.com/hashicorp/golang-lru"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-hamt-ipld"
+	cbornode "github.com/ipfs/go-ipld-cbor"
 	"github.com/opentracing/opentracing-go"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/messages/v2/build/go/gossip"
+	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
 )
 
 const (
@@ -47,41 +57,122 @@ func newRound(height uint64, alpha float64, beta int, k int) *round {
 
 type roundHolder struct {
 	sync.RWMutex
-	currentRound uint64
-	rounds       map[uint64]*round
+	currentRound *round
+	roundCache   *lru.Cache
+	dataStore    datastore.Batching
+	dagStore     nodestore.DagStore
+	hamtStore    *hamt.CborIpldStore
 }
 
-func newRoundHolder() *roundHolder {
+type roundHolderOpts struct {
+	DataStore datastore.Batching
+	DagStore  nodestore.DagStore
+	HamtStore *hamt.CborIpldStore
+}
+
+func newRoundHolder(opts *roundHolderOpts) (*roundHolder, error) {
+	cache, err := lru.New(64)
+	if err != nil {
+		return nil, fmt.Errorf("could not create LRU rounds cache: %w", err)
+	}
+
 	return &roundHolder{
-		rounds: make(map[uint64]*round),
-	}
-}
-
-func (rh *roundHolder) WithCompletedRounds(rounds... *round) *roundHolder {
-	for _, r := range rounds {
-		rh.rounds[r.height] = r
-	}
-
-	return rh
+		roundCache: cache,
+		dataStore:  opts.DataStore,
+		dagStore:   opts.DagStore,
+		hamtStore:  opts.HamtStore,
+	}, nil
 }
 
 func (rh *roundHolder) Current() *round {
 	rh.RLock()
-	r := rh.rounds[rh.currentRound]
-	rh.RUnlock()
-	return r
+	defer rh.RUnlock()
+	return rh.currentRound
+}
+
+func (rh *roundHolder) restoreRound(ctx context.Context, height uint64) (*round, error) {
+	key := roundKey(height)
+	roundCIDBytes, err := rh.dataStore.Get(key)
+	if err != nil {
+		return nil, fmt.Errorf("could not look up round for height %d: %w", height, err)
+	}
+
+	roundCID, err := cid.Cast(roundCIDBytes)
+	if err != nil {
+		return nil, fmt.Errorf("could not cast to CID: %w", err)
+	}
+
+	roundNode, err := rh.dagStore.Get(ctx, roundCID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get last completed round from DAG store: %w", err)
+	}
+
+	var gr gossip.Round
+	err = cbornode.DecodeInto(roundNode.RawData(), &gr)
+	if err != nil {
+		return nil, fmt.Errorf("could not decode round: %w", err)
+	}
+
+	rw := types.WrapRound(&gr)
+	rw.SetStore(rh.dagStore)
+
+	cp, err := rw.FetchCheckpoint(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch checkpoint from completed round: %w", err)
+	}
+
+	gs := newGlobalState(rh.hamtStore)
+	h, err := rw.FetchHamt(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("could not fetch HAMT: %w", err)
+	}
+	gs.hamt = h
+
+	r := &round{
+		height: gr.Height,
+		snowball: &Snowball{
+			preferred: &Vote{
+				Checkpoint: cp,
+			},
+		},
+		state: gs,
+	}
+
+	return r, nil
 }
 
 func (rh *roundHolder) Get(height uint64) (*round, bool) {
 	rh.RLock()
-	r, ok := rh.rounds[height]
-	rh.RUnlock()
-	return r, ok
+	defer rh.RUnlock()
+
+	if height == rh.currentRound.height {
+		return rh.currentRound, true
+	}
+
+	uncastRound, ok := rh.roundCache.Get(height)
+	if ok {
+		return uncastRound.(*round), ok
+	}
+
+	r, err := rh.restoreRound(context.TODO(), height)
+	if err != nil {
+		return nil, false
+	}
+
+	rh.roundCache.Add(height, r)
+
+	return r, true
 }
 
 func (rh *roundHolder) SetCurrent(r *round) {
 	rh.Lock()
-	rh.rounds[r.height] = r
-	rh.currentRound = r.height
-	rh.Unlock()
+	defer rh.Unlock()
+
+	// add the soon-to-be previous round to the LRU cache b/c we'll likely get
+	// it soon and this prevents race conditions with storing it
+	if rh.currentRound != nil {
+		rh.roundCache.Add(rh.currentRound.height, rh.currentRound)
+	}
+
+	rh.currentRound = r
 }

--- a/gossip/rounds.go
+++ b/gossip/rounds.go
@@ -6,9 +6,11 @@ import (
 	"sync"
 
 	lru "github.com/hashicorp/golang-lru"
-	cid "github.com/ipfs/go-cid"
-	hamt "github.com/ipfs/go-hamt-ipld"
+	"github.com/ipfs/go-cid"
+	"github.com/ipfs/go-datastore"
+	"github.com/ipfs/go-hamt-ipld"
 	cbornode "github.com/ipfs/go-ipld-cbor"
+	"github.com/opentracing/opentracing-go"
 	"github.com/quorumcontrol/chaintree/nodestore"
 	"github.com/quorumcontrol/messages/v2/build/go/gossip"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"

--- a/gossip/rounds_test.go
+++ b/gossip/rounds_test.go
@@ -1,14 +1,30 @@
 package gossip
 
 import (
+	"context"
 	"testing"
 
+	"github.com/ipfs/go-datastore"
+	dsync "github.com/ipfs/go-datastore/sync"
+	"github.com/quorumcontrol/chaintree/nodestore"
+	"github.com/quorumcontrol/tupelo-go-sdk/gossip/hamtwrapper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestRoundHolderSetCurrent(t *testing.T) {
-	rh := newRoundHolder()
+	ctx := context.Background()
+	dataStore := dsync.MutexWrap(datastore.NewMapDatastore())
+	dagStore := nodestore.MustMemoryStore(ctx)
+	hamtStore := hamtwrapper.DagStoreToCborIpld(dagStore)
+
+	rhOpts := &roundHolderOpts{
+		DataStore: dataStore,
+		DagStore:  dagStore,
+		HamtStore: hamtStore,
+	}
+	rh, err := newRoundHolder(rhOpts)
+	require.Nil(t, err)
 
 	rh.SetCurrent(newRound(0, 0, 0, 0))
 	require.Equal(t, uint64(0), rh.Current().height)
@@ -18,7 +34,18 @@ func TestRoundHolderSetCurrent(t *testing.T) {
 }
 
 func TestRoundHolderGet(t *testing.T) {
-	rh := newRoundHolder()
+	ctx := context.Background()
+	dataStore := dsync.MutexWrap(datastore.NewMapDatastore())
+	dagStore := nodestore.MustMemoryStore(ctx)
+	hamtStore := hamtwrapper.DagStoreToCborIpld(dagStore)
+
+	rhOpts := &roundHolderOpts{
+		DataStore: dataStore,
+		DagStore:  dagStore,
+		HamtStore: hamtStore,
+	}
+	rh, err := newRoundHolder(rhOpts)
+	require.Nil(t, err)
 
 	r := newRound(0, 0, 0, 0)
 	rh.SetCurrent(r)

--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -21,6 +21,8 @@ import (
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
 )
 
+const paralellCount = 2
+
 type snowballer struct {
 	sync.RWMutex
 
@@ -31,6 +33,11 @@ type snowballer struct {
 	group    *types.NotaryGroup
 	logger   logging.EventLogger
 	cache    *lru.Cache
+
+	parentCtx     context.Context
+	parentCtxStop context.CancelFunc
+
+	respChan chan *snowballVoteResp
 
 	started bool
 }
@@ -53,6 +60,7 @@ func newSnowballer(n *Node, height uint64, snowball *Snowball) *snowballer {
 		logger:   n.logger,
 		cache:    cache,
 		height:   height,
+		respChan: make(chan *snowballVoteResp, snowball.k*paralellCount),
 	}
 }
 
@@ -89,14 +97,41 @@ func (snb *snowballer) Start(ctx context.Context) {
 		snb.logger.Debugf("preferred id: %s", snb.snowball.Preferred().ID())
 	}
 
+	snowballerCtx, cancel := context.WithCancel(ctx)
+	snb.parentCtx = snowballerCtx
+	snb.parentCtxStop = cancel
+
+	stopSampling := snowballerCtx.Done()
+
+	// start populating results
+	go func() {
+		tokenCh := make(chan struct{}, snb.snowball.k*paralellCount)
+		for i := 0; i < snb.snowball.k*paralellCount; i++ {
+			tokenCh <- struct{}{}
+		}
+
+		for {
+			select {
+			case <-stopSampling:
+				return // stop the sample
+			case <-tokenCh:
+				go snb.getOneRandomVote(snb.parentCtx, tokenCh)
+			}
+
+		}
+	}()
+
 	go func() {
 		done := make(chan error, 1)
 		snb.run(ctx, done)
 
+		ctxDone := snowballerCtx.Done()
+
 		select {
-		case <-ctx.Done():
+		case <-ctxDone:
 			return
 		case err := <-done:
+			snb.parentCtxStop()
 			snb.node.rootContext.Send(snb.node.pid, &snowballerDone{err: err, ctx: ctx})
 		}
 	}()
@@ -107,7 +142,6 @@ func (snb *snowballer) run(startCtx context.Context, done chan error) {
 	sp := opentracing.StartSpan("gossip4.snowballer.start")
 	defer sp.Finish()
 	ctx := opentracing.ContextWithSpan(startCtx, sp)
-
 	ctxDone := ctx.Done()
 
 	for !snb.snowball.Decided() {
@@ -119,6 +153,7 @@ func (snb *snowballer) run(startCtx context.Context, done chan error) {
 		default:
 			//nothing to do here
 		}
+
 		snb.doTick(ctx)
 	}
 
@@ -132,19 +167,20 @@ func (snb *snowballer) doTick(startCtx context.Context) {
 
 	sp.LogKV("height", snb.height)
 
-	respChan := make(chan *snowballVoteResp, snb.snowball.k)
-	wg := &sync.WaitGroup{}
-	for i := 0; i < snb.snowball.k; i++ {
-		wg.Add(1)
-		go func() {
-			snb.getOneRandomVote(ctx, wg, respChan)
-		}()
+	sampleSize := snb.snowball.k
+
+	responses := make([]*snowballVoteResp, sampleSize)
+	for i := 0; i < sampleSize; i++ {
+		responses[i] = <-snb.respChan // this channel is being populated in another go routine
 	}
-	wg.Wait()
-	close(respChan)
-	votes := make([]*Vote, snb.snowball.k)
-	i := 0
-	for resp := range respChan {
+	votes := make([]*Vote, sampleSize)
+	for i, resp := range responses {
+		if resp == nil {
+			v := &Vote{}
+			v.Nil()
+			votes[i] = v
+			continue
+		}
 		wrappedCheckpoint := resp.wrappedCheckpoint
 		snb.logger.Debugf("%s checkpoint: %v", resp.signerID, wrappedCheckpoint.Value())
 		vote := &Vote{
@@ -160,15 +196,6 @@ func (snb *snowballer) doTick(startCtx context.Context) {
 			vote.Nil()
 		}
 		votes[i] = vote
-		i++
-	}
-
-	if i < len(votes) {
-		for j := i; j < len(votes); j++ {
-			v := &Vote{}
-			v.Nil()
-			votes[j] = v
-		}
 	}
 
 	votes = calculateTallies(votes)
@@ -178,13 +205,18 @@ func (snb *snowballer) doTick(startCtx context.Context) {
 	// snb.logger.Debugf("counts: %v, beta: %d", snb.snowball.counts, snb.snowball.count)
 }
 
-func (snb *snowballer) getOneRandomVote(parentCtx context.Context, wg *sync.WaitGroup, respChan chan *snowballVoteResp) {
+func (snb *snowballer) getOneRandomVote(parentCtx context.Context, tokenCh chan struct{}) {
 	sp, ctx := opentracing.StartSpanFromContext(parentCtx, "gossip4.snowballer.getOneRandomVote")
 	defer sp.Finish()
 
+	var resp *snowballVoteResp // set up here so that we can add a nil response to the resp channel on error
+
 	var signer *types.Signer
 	var signerPeer string
-	defer wg.Done()
+	defer func() {
+		snb.respChan <- resp  // this will block when we don't need any more responses
+		tokenCh <- struct{}{} // and then this will let the sampler continue to get more responses
+	}()
 
 	// pick one non-self signer
 	for signer == nil || signerPeer == snb.host.Identity() {
@@ -257,7 +289,7 @@ func (snb *snowballer) getOneRandomVote(parentCtx context.Context, wg *sync.Wait
 		snb.cache.Add(id, wrappedCheckpoint)
 	}
 
-	respChan <- &snowballVoteResp{
+	resp = &snowballVoteResp{
 		signerID:          signerPeer,
 		wrappedCheckpoint: wrappedCheckpoint,
 	}

--- a/gossip/txvalidator_test.go
+++ b/gossip/txvalidator_test.go
@@ -25,8 +25,7 @@ func TestTransactionValidator(t *testing.T) {
 
 	numMembers := 1
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	ng, nodes, err := newTupeloSystem(ctx, t, ts)
-	require.Nil(t, err)
+	ng, nodes := newTupeloSystem(ctx, t, ts)
 	require.Len(t, nodes, numMembers)
 
 	fut := actor.NewFuture(5 * time.Second)
@@ -72,8 +71,7 @@ func BenchmarkTransactionValidator(b *testing.B) {
 
 	numMembers := 1
 	ts := testnotarygroup.NewTestSet(b, numMembers)
-	ng, nodes, err := newTupeloSystem(ctx, b, ts)
-	require.Nil(b, err)
+	ng, nodes := newTupeloSystem(ctx, b, ts)
 	require.Len(b, nodes, numMembers)
 
 	wg := &sync.WaitGroup{}

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -3,6 +3,7 @@ package nodebuilder
 import (
 	"crypto/ecdsa"
 
+	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/quorumcontrol/tupelo-go-sdk/bls"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
@@ -41,4 +42,5 @@ type Config struct {
 	BootstrapOnly bool
 
 	Blockstore blockstore.Blockstore
+	Datastore  datastore.Batching
 }

--- a/nodebuilder/humanconfig.go
+++ b/nodebuilder/humanconfig.go
@@ -138,6 +138,12 @@ func HumanConfigToConfig(hc HumanConfig) (*Config, error) {
 
 	c.Blockstore = bstore
 
+	dstore, err := hc.Storage.ToDatastore()
+	if err != nil {
+		return nil, fmt.Errorf("error converting to datastore: %v", err)
+	}
+	c.Datastore = dstore
+
 	return c, nil
 }
 

--- a/nodebuilder/localnetwork.go
+++ b/nodebuilder/localnetwork.go
@@ -3,8 +3,6 @@ package nodebuilder
 import (
 	"context"
 	"fmt"
-	"path"
-	"strconv"
 	"strings"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
@@ -52,8 +50,7 @@ func NewLocalNetwork(ctx context.Context, namespace string, keys []*PrivateKeySe
 	configs := make([]*Config, len(signers))
 	for i, keySet := range keys {
 		hsc := &HumanStorageConfig{
-			Kind: "badger",
-			Path: path.Join(configDir(namespace, localConfigName), strconv.Itoa(i)),
+			Kind: "memory",
 		}
 
 		bstore, err := hsc.ToBlockstore()
@@ -61,11 +58,17 @@ func NewLocalNetwork(ctx context.Context, namespace string, keys []*PrivateKeySe
 			return nil, fmt.Errorf("error setting up badger blockstore: %v", err)
 		}
 
+		dstore, err := hsc.ToDatastore()
+		if err != nil {
+			return nil, fmt.Errorf("error setting up badger datastore: %v", err)
+		}
+
 		configs[i] = &Config{
 			NotaryGroupConfig: ngConfig,
 			PrivateKeySet:     keySet,
 			BootstrapNodes:    ln.BootstrapAddrrs,
 			Blockstore:        bstore,
+			Datastore:         dstore,
 		}
 	}
 

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -195,6 +195,7 @@ func (nb *NodeBuilder) startSigner(ctx context.Context) (*p2p.LibP2PHost, error)
 		SignKey:     localKeys.SignKey,
 		NotaryGroup: group,
 		DagStore:    bitswapper,
+		Datastore:   nb.Config.Datastore,
 	}
 
 	node, err := gossip.NewNode(ctx, nodeCfg)

--- a/nodebuilder/nodebuilder_test.go
+++ b/nodebuilder/nodebuilder_test.go
@@ -69,6 +69,9 @@ func TestSigner(t *testing.T) {
 		bstore, err := hsc.ToBlockstore()
 		require.Nil(t, err)
 
+		dstore, err := hsc.ToDatastore()
+		require.Nil(t, err)
+
 		nb := &NodeBuilder{
 			Config: &Config{
 				NotaryGroupConfig: ngConfig,
@@ -77,6 +80,7 @@ func TestSigner(t *testing.T) {
 					SignKey: ts.SignKeys[0],
 				},
 				Blockstore:     bstore,
+				Datastore:      dstore,
 				BootstrapNodes: addrs,
 			},
 		}


### PR DESCRIPTION
[Trello card](https://trello.com/c/xGGQRs0E)

I did this in two phases (see commit history) where I started out by storing and restoring the full round history instead of just the most recent completed round.

I then refactored that into making roundHolder do a storage lookup w/ an LRU cache (which I sized at 64 elements for basically arbitrary reasons) to fix the memory leak.

Note that this will reset testnet if deployed because the state store key names have changed. It didn't seem worth coding up a migration for that at this stage.