### PR TITLE
Revert "allow parallel network sampling"

### DIFF
--- a/gossip/snowballnetwork.go
+++ b/gossip/snowballnetwork.go
@@ -21,8 +21,6 @@ import (
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
 )
 
-const paralellCount = 2
-
 type snowballer struct {
 	sync.RWMutex
 
@@ -33,11 +31,6 @@ type snowballer struct {
 	group    *types.NotaryGroup
 	logger   logging.EventLogger
 	cache    *lru.Cache
-
-	parentCtx     context.Context
-	parentCtxStop context.CancelFunc
-
-	respChan chan *snowballVoteResp
 
 	started bool
 }
@@ -60,7 +53,6 @@ func newSnowballer(n *Node, height uint64, snowball *Snowball) *snowballer {
 		logger:   n.logger,
 		cache:    cache,
 		height:   height,
-		respChan: make(chan *snowballVoteResp, snowball.k*paralellCount),
 	}
 }
 
@@ -97,41 +89,14 @@ func (snb *snowballer) Start(ctx context.Context) {
 		snb.logger.Debugf("preferred id: %s", snb.snowball.Preferred().ID())
 	}
 
-	snowballerCtx, cancel := context.WithCancel(ctx)
-	snb.parentCtx = snowballerCtx
-	snb.parentCtxStop = cancel
-
-	stopSampling := snowballerCtx.Done()
-
-	// start populating results
-	go func() {
-		tokenCh := make(chan struct{}, snb.snowball.k*paralellCount)
-		for i := 0; i < snb.snowball.k*paralellCount; i++ {
-			tokenCh <- struct{}{}
-		}
-
-		for {
-			select {
-			case <-stopSampling:
-				return // stop the sample
-			case <-tokenCh:
-				go snb.getOneRandomVote(snb.parentCtx, tokenCh)
-			}
-
-		}
-	}()
-
 	go func() {
 		done := make(chan error, 1)
 		snb.run(ctx, done)
 
-		ctxDone := snowballerCtx.Done()
-
 		select {
-		case <-ctxDone:
+		case <-ctx.Done():
 			return
 		case err := <-done:
-			snb.parentCtxStop()
 			snb.node.rootContext.Send(snb.node.pid, &snowballerDone{err: err, ctx: ctx})
 		}
 	}()
@@ -142,6 +107,7 @@ func (snb *snowballer) run(startCtx context.Context, done chan error) {
 	sp := opentracing.StartSpan("gossip4.snowballer.start")
 	defer sp.Finish()
 	ctx := opentracing.ContextWithSpan(startCtx, sp)
+
 	ctxDone := ctx.Done()
 
 	for !snb.snowball.Decided() {
@@ -153,7 +119,6 @@ func (snb *snowballer) run(startCtx context.Context, done chan error) {
 		default:
 			//nothing to do here
 		}
-
 		snb.doTick(ctx)
 	}
 
@@ -167,20 +132,19 @@ func (snb *snowballer) doTick(startCtx context.Context) {
 
 	sp.LogKV("height", snb.height)
 
-	sampleSize := snb.snowball.k
-
-	responses := make([]*snowballVoteResp, sampleSize)
-	for i := 0; i < sampleSize; i++ {
-		responses[i] = <-snb.respChan // this channel is being populated in another go routine
+	respChan := make(chan *snowballVoteResp, snb.snowball.k)
+	wg := &sync.WaitGroup{}
+	for i := 0; i < snb.snowball.k; i++ {
+		wg.Add(1)
+		go func() {
+			snb.getOneRandomVote(ctx, wg, respChan)
+		}()
 	}
-	votes := make([]*Vote, sampleSize)
-	for i, resp := range responses {
-		if resp == nil {
-			v := &Vote{}
-			v.Nil()
-			votes[i] = v
-			continue
-		}
+	wg.Wait()
+	close(respChan)
+	votes := make([]*Vote, snb.snowball.k)
+	i := 0
+	for resp := range respChan {
 		wrappedCheckpoint := resp.wrappedCheckpoint
 		snb.logger.Debugf("%s checkpoint: %v", resp.signerID, wrappedCheckpoint.Value())
 		vote := &Vote{
@@ -196,6 +160,15 @@ func (snb *snowballer) doTick(startCtx context.Context) {
 			vote.Nil()
 		}
 		votes[i] = vote
+		i++
+	}
+
+	if i < len(votes) {
+		for j := i; j < len(votes); j++ {
+			v := &Vote{}
+			v.Nil()
+			votes[j] = v
+		}
 	}
 
 	votes = calculateTallies(votes)
@@ -205,18 +178,13 @@ func (snb *snowballer) doTick(startCtx context.Context) {
 	// snb.logger.Debugf("counts: %v, beta: %d", snb.snowball.counts, snb.snowball.count)
 }
 
-func (snb *snowballer) getOneRandomVote(parentCtx context.Context, tokenCh chan struct{}) {
+func (snb *snowballer) getOneRandomVote(parentCtx context.Context, wg *sync.WaitGroup, respChan chan *snowballVoteResp) {
 	sp, ctx := opentracing.StartSpanFromContext(parentCtx, "gossip4.snowballer.getOneRandomVote")
 	defer sp.Finish()
 
-	var resp *snowballVoteResp // set up here so that we can add a nil response to the resp channel on error
-
 	var signer *types.Signer
 	var signerPeer string
-	defer func() {
-		snb.respChan <- resp  // this will block when we don't need any more responses
-		tokenCh <- struct{}{} // and then this will let the sampler continue to get more responses
-	}()
+	defer wg.Done()
 
 	// pick one non-self signer
 	for signer == nil || signerPeer == snb.host.Identity() {
@@ -289,7 +257,7 @@ func (snb *snowballer) getOneRandomVote(parentCtx context.Context, tokenCh chan 
 		snb.cache.Add(id, wrappedCheckpoint)
 	}
 
-	resp = &snowballVoteResp{
+	respChan <- &snowballVoteResp{
 		signerID:          signerPeer,
 		wrappedCheckpoint: wrappedCheckpoint,
 	}


### PR DESCRIPTION
Reverts quorumcontrol/tupelo#429

Turns out this was showing us a bug:

```
but in the idealized version of the bug...
nodes A through D all have 0 txs in their mempool
now nowd E(vil) comes in and pings A with a snowball request for currentRound+1
so A calls B and B calls C and C calls D
but none have any Txs in their mempool
so they all snowball nil
but now they've all started snowballing
so they can never stop
```