### PR TITLE
Revert "Persist last completed round & restore state from it on start"

### DIFF
--- a/configs/localdocker/node0/config.toml
+++ b/configs/localdocker/node0/config.toml
@@ -3,7 +3,3 @@ NotaryGroupConfig = "../localdocker.toml"
 [PrivateKeySet]
 SignKeyHex = "0x4344e3372f1b790016ed86400611fab64d0bba91136518685a7ce34106f1c759"
 DestKeyHex = "0xc09363e85290020c132053f029f23988d4e35c521b0698312e0071f3e5d0e023"
-
-[Storage]
-Kind = "badger"
-Path = "/tupelo/data"

--- a/configs/localdocker/node1/config.toml
+++ b/configs/localdocker/node1/config.toml
@@ -1,9 +1,6 @@
 NotaryGroupConfig = "../localdocker.toml"
 
+
 [PrivateKeySet]
 SignKeyHex = "0x39a9b8ab3266811852b8b18d1fd0562ffc907f3ecba297c9b2a89f742d349dc9"
 DestKeyHex = "0xa1b8b9936d8072b1a16311aee414289a5f8070acff847588386738d6d686fc9b"
-
-[Storage]
-Kind = "badger"
-Path = "/tupelo/data"

--- a/configs/localdocker/node2/config.toml
+++ b/configs/localdocker/node2/config.toml
@@ -3,7 +3,3 @@ NotaryGroupConfig = "../localdocker.toml"
 [PrivateKeySet]
 SignKeyHex = "0x558a546adacea3d761741bf4a6415ef2eeb85bfa457036b59564fa88ee276cf5"
 DestKeyHex = "0x251b3227fc393f810846f170c1534c2787721a4385d4711d93321302bf023bab"
-
-[Storage]
-Kind = "badger"
-Path = "/tupelo/data"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,6 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
-      - ./.tmp/node0/data:/tupelo/data
     command: ["node", "--config", "/configs/node0/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
 
@@ -40,7 +39,6 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
-      - ./.tmp/node1/data:/tupelo/data
     command: ["node", "--config", "/configs/node1/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
   
@@ -50,7 +48,6 @@ services:
     build: .
     volumes:
       - ./configs/localdocker:/configs
-      - ./.tmp/node2/data:/tupelo/data
     command: ["node", "--config", "/configs/node2/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
 

--- a/gossip/benchmark/benchmark_test.go
+++ b/gossip/benchmark/benchmark_test.go
@@ -7,8 +7,6 @@ import (
 	"time"
 
 	"github.com/ipfs/go-bitswap"
-	"github.com/ipfs/go-datastore"
-	dsync "github.com/ipfs/go-datastore/sync"
 	logging "github.com/ipfs/go-log"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/client"
@@ -20,7 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTupeloSystem(ctx context.Context, t testing.TB, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*gossip.Node) {
+func newTupeloSystem(ctx context.Context, testSet *testnotarygroup.TestSet) (*types.NotaryGroup, []*gossip.Node, error) {
 	nodes := make([]*gossip.Node, len(testSet.SignKeys))
 
 	ng := types.NewNotaryGroup("testnotary")
@@ -32,29 +30,31 @@ func newTupeloSystem(ctx context.Context, t testing.TB, testSet *testnotarygroup
 
 	for i := range ng.AllSigners() {
 		p2pNode, peer, err := p2p.NewHostAndBitSwapPeer(ctx, p2p.WithKey(testSet.EcdsaKeys[i]), p2p.WithBitswapOptions(bitswap.ProvideEnabled(false)))
-		require.Nil(t, err)
-
-		dataStore := dsync.MutexWrap(datastore.NewMapDatastore())
+		if err != nil {
+			return nil, nil, fmt.Errorf("error making node: %v", err)
+		}
 
 		n, err := gossip.NewNode(ctx, &gossip.NewNodeOptions{
 			P2PNode:     p2pNode,
 			SignKey:     testSet.SignKeys[i],
 			NotaryGroup: ng,
 			DagStore:    peer,
-			Datastore:   dataStore,
 		})
-		require.Nil(t, err)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error making node: %v", err)
+		}
 		nodes[i] = n
 	}
 	// setting log level to debug because it's useful output on test failures
 	// this happens after the AllSigners loop because the node name is based on the
 	// index in the signers
 	for i := range ng.AllSigners() {
-		err := logging.SetLogLevel(fmt.Sprintf("node-%d", i), "debug")
-		require.Nil(t, err)
+		if err := logging.SetLogLevel(fmt.Sprintf("node-%d", i), "debug"); err != nil {
+			return nil, nil, fmt.Errorf("error setting log level: %v", err)
+		}
 	}
 
-	return ng, nodes
+	return ng, nodes, nil
 }
 
 func startNodes(t *testing.T, ctx context.Context, nodes []*gossip.Node, bootAddrs []string) {
@@ -97,7 +97,8 @@ func TestBenchmarker(t *testing.T) {
 
 	numMembers := 3
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	group, nodes := newTupeloSystem(ctx, t, ts)
+	group, nodes, err := newTupeloSystem(ctx, ts)
+	require.Nil(t, err)
 	require.Len(t, nodes, numMembers)
 
 	booter, err := p2p.NewHostFromOptions(ctx)

--- a/gossip/node.go
+++ b/gossip/node.go
@@ -8,13 +8,13 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/AsynkronIT/protoactor-go/actor"
 	lru "github.com/hashicorp/golang-lru"
-	"github.com/ipfs/go-datastore"
 	cbornode "github.com/ipfs/go-ipld-cbor"
+	"github.com/opentracing/opentracing-go"
+
+	"github.com/AsynkronIT/protoactor-go/actor"
 	pubsub "github.com/libp2p/go-libp2p-pubsub"
 	msgio "github.com/libp2p/go-msgio"
-	"github.com/opentracing/opentracing-go"
 
 	cid "github.com/ipfs/go-cid"
 	hamt "github.com/ipfs/go-hamt-ipld"
@@ -31,7 +31,6 @@ import (
 )
 
 const gossipProtocol = "tupelo/v0.0.1"
-const lastCompletedRoundCIDKey = "/Snowball/LastCompletedRound"
 
 type startSnowball struct {
 	ctx context.Context
@@ -45,7 +44,6 @@ type Node struct {
 	notaryGroup *types.NotaryGroup
 	dagStore    nodestore.DagStore
 	hamtStore   *hamt.CborIpldStore
-	dataStore   datastore.Batching
 	pubsub      *pubsub.PubSub
 
 	mempool  *mempool
@@ -78,7 +76,6 @@ type NewNodeOptions struct {
 	SignKey          *bls.SignKey
 	NotaryGroup      *types.NotaryGroup
 	DagStore         nodestore.DagStore
-	Datastore        datastore.Batching
 	Name             string             // optional
 	RootActorContext *actor.RootContext // optional
 }
@@ -106,94 +103,38 @@ func NewNode(ctx context.Context, opts *NewNodeOptions) (*Node, error) {
 		return nil, fmt.Errorf("error creating cache: %w", err)
 	}
 
-	nodeName := opts.Name
-	if nodeName == "" {
-		nodeName = fmt.Sprintf("node-%d", signerIndex)
-	}
-
-	logger := logging.Logger(nodeName)
-	logger.Debugf("signerIndex: %d", signerIndex)
-
-	dataStore := opts.Datastore
-	dagStore := opts.DagStore
-	roundCIDBytes, err := dataStore.Get(datastore.NewKey(lastCompletedRoundCIDKey))
-	if err != nil && err != datastore.ErrNotFound {
-		return nil, fmt.Errorf("could not look up last completed round: %w", err)
-	}
-
+	// TODO: we need a way to bootstrap a node coming back up and not in the genesis state.
+	// shouldn't be too hard, just save the latest round into a key/value store somewhere
+	// and then it can come back up and bootstrap itself up to the latest in the network
 	holder := newRoundHolder()
-	var height uint64
-	if err == datastore.ErrNotFound {
-		height = uint64(0)
-	} else {
-		roundCID, err := cid.Cast(roundCIDBytes)
-		if err != nil {
-			return nil, fmt.Errorf("could not cast to CID: %w", err)
-		}
-		roundNode, err := dagStore.Get(ctx, roundCID)
-		if err != nil {
-			return nil, fmt.Errorf("could not get last completed round from DAG store: %w", err)
-		}
-
-		var gr gossip.Round
-		err = cbornode.DecodeInto(roundNode.RawData(), &gr)
-		if err != nil {
-			return nil, fmt.Errorf("could not decode round: %w", err)
-		}
-
-		rw := types.WrapRound(&gr)
-		rw.SetStore(dagStore)
-
-		cp, err := rw.FetchCheckpoint(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not fetch checkpoint from completed round: %w", err)
-		}
-
-		gs := newGlobalState(hamtStore)
-		h, err := rw.FetchHamt(ctx)
-		if err != nil {
-			return nil, fmt.Errorf("could not fetch HAMT: %w", err)
-		}
-		gs.hamt = h
-
-		r := &round{
-			height: gr.Height,
-			snowball: &Snowball{
-				preferred: &Vote{
-					Checkpoint: cp,
-				},
-			},
-			state: gs,
-		}
-
-		holder = holder.WithCompletedRounds(r)
-		height = r.height + 1
-	}
-	r := newRound(height, 0, 0, min(defaultK, int(opts.NotaryGroup.Size())-1))
-	logger.Infof("initializing snowball at height: %d with alpha: %f, beta: %d, and k: %d",
-		r.height, r.snowball.alpha, r.snowball.beta, r.snowball.k)
+	r := newRound(0, 0, 0, min(defaultK, int(opts.NotaryGroup.Size())-1))
 	holder.SetCurrent(r)
 
 	n := &Node{
-		name:        nodeName,
+		name:        opts.Name,
 		p2pNode:     opts.P2PNode,
 		signKey:     opts.SignKey,
 		notaryGroup: opts.NotaryGroup,
-		dagStore:    dagStore,
+		dagStore:    opts.DagStore,
 		hamtStore:   hamtStore,
-		dataStore:   dataStore,
 		rounds:      holder,
 		signerIndex: signerIndex,
 		inflight:    cache,
 		mempool:     newMempool(),
 		rootContext: opts.RootActorContext,
-		logger:      logger,
 	}
 
 	if n.rootContext == nil {
 		n.rootContext = actor.EmptyRootContext
 	}
 
+	if n.name == "" {
+		n.name = fmt.Sprintf("node-%d", signerIndex)
+	}
+
+	logger := logging.Logger(n.name)
+	logger.Debugf("signerIndex: %d", signerIndex)
+	n.logger = logger
 
 	networkedSnowball := newSnowballer(n, r.height, r.snowball)
 	n.snowballer = networkedSnowball
@@ -411,11 +352,6 @@ func (n *Node) publishCompletedRound(ctx context.Context, round *round) error {
 	err = n.dagStore.Add(ctx, wrappedCompletedRound.Wrapped())
 	if err != nil {
 		return fmt.Errorf("error adding to dag store: %w", err)
-	}
-
-	err = n.dataStore.Put(datastore.NewKey(lastCompletedRoundCIDKey), wrappedCompletedRound.CID().Bytes())
-	if err != nil {
-		return fmt.Errorf("error storing completed round CID: %w", err)
 	}
 
 	conf, err := n.confirmCompletedRound(ctx, wrappedCompletedRound)

--- a/gossip/rounds.go
+++ b/gossip/rounds.go
@@ -57,14 +57,6 @@ func newRoundHolder() *roundHolder {
 	}
 }
 
-func (rh *roundHolder) WithCompletedRounds(rounds... *round) *roundHolder {
-	for _, r := range rounds {
-		rh.rounds[r.height] = r
-	}
-
-	return rh
-}
-
 func (rh *roundHolder) Current() *round {
 	rh.RLock()
 	r := rh.rounds[rh.currentRound]

--- a/gossip/txvalidator_test.go
+++ b/gossip/txvalidator_test.go
@@ -25,7 +25,8 @@ func TestTransactionValidator(t *testing.T) {
 
 	numMembers := 1
 	ts := testnotarygroup.NewTestSet(t, numMembers)
-	ng, nodes := newTupeloSystem(ctx, t, ts)
+	ng, nodes, err := newTupeloSystem(ctx, t, ts)
+	require.Nil(t, err)
 	require.Len(t, nodes, numMembers)
 
 	fut := actor.NewFuture(5 * time.Second)
@@ -71,7 +72,8 @@ func BenchmarkTransactionValidator(b *testing.B) {
 
 	numMembers := 1
 	ts := testnotarygroup.NewTestSet(b, numMembers)
-	ng, nodes := newTupeloSystem(ctx, b, ts)
+	ng, nodes, err := newTupeloSystem(ctx, b, ts)
+	require.Nil(b, err)
 	require.Len(b, nodes, numMembers)
 
 	wg := &sync.WaitGroup{}

--- a/nodebuilder/config.go
+++ b/nodebuilder/config.go
@@ -3,7 +3,6 @@ package nodebuilder
 import (
 	"crypto/ecdsa"
 
-	"github.com/ipfs/go-datastore"
 	blockstore "github.com/ipfs/go-ipfs-blockstore"
 	"github.com/quorumcontrol/tupelo-go-sdk/bls"
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
@@ -42,5 +41,4 @@ type Config struct {
 	BootstrapOnly bool
 
 	Blockstore blockstore.Blockstore
-	Datastore  datastore.Batching
 }

--- a/nodebuilder/humanconfig.go
+++ b/nodebuilder/humanconfig.go
@@ -138,12 +138,6 @@ func HumanConfigToConfig(hc HumanConfig) (*Config, error) {
 
 	c.Blockstore = bstore
 
-	dstore, err := hc.Storage.ToDatastore()
-	if err != nil {
-		return nil, fmt.Errorf("error converting to datastore: %v", err)
-	}
-	c.Datastore = dstore
-
 	return c, nil
 }
 

--- a/nodebuilder/localnetwork.go
+++ b/nodebuilder/localnetwork.go
@@ -3,6 +3,8 @@ package nodebuilder
 import (
 	"context"
 	"fmt"
+	"path"
+	"strconv"
 	"strings"
 
 	"github.com/quorumcontrol/tupelo-go-sdk/gossip/types"
@@ -50,7 +52,8 @@ func NewLocalNetwork(ctx context.Context, namespace string, keys []*PrivateKeySe
 	configs := make([]*Config, len(signers))
 	for i, keySet := range keys {
 		hsc := &HumanStorageConfig{
-			Kind: "memory",
+			Kind: "badger",
+			Path: path.Join(configDir(namespace, localConfigName), strconv.Itoa(i)),
 		}
 
 		bstore, err := hsc.ToBlockstore()
@@ -58,17 +61,11 @@ func NewLocalNetwork(ctx context.Context, namespace string, keys []*PrivateKeySe
 			return nil, fmt.Errorf("error setting up badger blockstore: %v", err)
 		}
 
-		dstore, err := hsc.ToDatastore()
-		if err != nil {
-			return nil, fmt.Errorf("error setting up badger datastore: %v", err)
-		}
-
 		configs[i] = &Config{
 			NotaryGroupConfig: ngConfig,
 			PrivateKeySet:     keySet,
 			BootstrapNodes:    ln.BootstrapAddrrs,
 			Blockstore:        bstore,
-			Datastore:         dstore,
 		}
 	}
 

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -195,7 +195,6 @@ func (nb *NodeBuilder) startSigner(ctx context.Context) (*p2p.LibP2PHost, error)
 		SignKey:     localKeys.SignKey,
 		NotaryGroup: group,
 		DagStore:    bitswapper,
-		Datastore:   nb.Config.Datastore,
 	}
 
 	node, err := gossip.NewNode(ctx, nodeCfg)

--- a/nodebuilder/nodebuilder_test.go
+++ b/nodebuilder/nodebuilder_test.go
@@ -69,9 +69,6 @@ func TestSigner(t *testing.T) {
 		bstore, err := hsc.ToBlockstore()
 		require.Nil(t, err)
 
-		dstore, err := hsc.ToDatastore()
-		require.Nil(t, err)
-
 		nb := &NodeBuilder{
 			Config: &Config{
 				NotaryGroupConfig: ngConfig,
@@ -80,7 +77,6 @@ func TestSigner(t *testing.T) {
 					SignKey: ts.SignKeys[0],
 				},
 				Blockstore:     bstore,
-				Datastore:      dstore,
 				BootstrapNodes: addrs,
 			},
 		}


### PR DESCRIPTION
Reverts quorumcontrol/tupelo#441

Turns out that the case in #441 where the network is saved at different spots is actually happening during benchmarks. We think #442 will fix, this but makes testing new things harder.