### PR TITLE
only republish a round after it has already been published

### DIFF
--- a/gossip/node.go
+++ b/gossip/node.go
@@ -232,7 +232,8 @@ func (n *Node) maybeRepublish(ctx context.Context) {
 
 	if round := n.rounds.Current(); round != nil {
 		previousRound, found := n.rounds.Get(round.height - 1)
-		if found && previousRound != nil {
+
+		if found && previousRound != nil && previousRound.published {
 			n.logger.Debugf("republishing round: %d", previousRound.height)
 			n.publishCompletedRound(ctx, previousRound)
 		}
@@ -329,6 +330,7 @@ func (n *Node) publishCompletedRound(ctx context.Context, round *round) error {
 	if err != nil {
 		return fmt.Errorf("error getting current state cid: %v", err)
 	}
+	n.logger.Infof("publishCompletedRound height %d currentState: %s", round.height, currentStateCid.String())
 
 	if !round.snowball.Decided() {
 		return fmt.Errorf("can't publish an undecided round")
@@ -360,6 +362,8 @@ func (n *Node) publishCompletedRound(ctx context.Context, round *round) error {
 	}
 
 	n.logger.Debugf("publishing round confirmed to: %s", n.notaryGroup.ID)
+
+	defer func() { round.published = true }()
 
 	return n.pubsub.Publish(n.notaryGroup.ID, conf.Data())
 }

--- a/gossip/node.go
+++ b/gossip/node.go
@@ -330,7 +330,7 @@ func (n *Node) publishCompletedRound(ctx context.Context, round *round) error {
 	if err != nil {
 		return fmt.Errorf("error getting current state cid: %v", err)
 	}
-	n.logger.Infof("publishCompletedRound height %d currentState: %s", round.height, currentStateCid.String())
+	n.logger.Debugf("publishCompletedRound height %d currentState: %s", round.height, currentStateCid.String())
 
 	if !round.snowball.Decided() {
 		return fmt.Errorf("can't publish an undecided round")

--- a/gossip/rounds.go
+++ b/gossip/rounds.go
@@ -17,6 +17,8 @@ type round struct {
 	height   uint64
 	state    *globalState
 	sp       opentracing.Span
+
+	published bool
 }
 
 func newRound(height uint64, alpha float64, beta int, k int) *round {


### PR DESCRIPTION
we found a bug where the fault-detector was showing faults on round publishing. Turns out we were publishing rounds before they were ready to be published in our "republish"

That worked like this:

1. Round decided, moves into background processing
2. The "maybe republish" fires and sees that snowball isn't yet started
3. That calls republish, but the previous round is *not* ready for republishing yet, so we get an old stale state published.

This limits to make sure that if we're *republishing* that we've at least published once.