### PR TITLE
Cleaner end-of-run logging that doesn’t block the pubsub subscriptions

### DIFF
--- a/cmd/benchmark.go
+++ b/cmd/benchmark.go
@@ -60,8 +60,10 @@ var benchmarkCmd = &cobra.Command{
 			panic(fmt.Errorf("error getting notary group: %v", err))
 		}
 
+		var fd *benchmark.FaultDetector
+
 		if benchmarkRunFaultDetection {
-			fd := &benchmark.FaultDetector{
+			fd = &benchmark.FaultDetector{
 				P2PNode:  p2pHost,
 				DagStore: peer,
 				Group:    group,
@@ -80,6 +82,10 @@ var benchmarkCmd = &cobra.Command{
 		}
 
 		b := benchmark.NewBenchmark(cli, benchmarkConcurrency, time.Duration(benchmarkDuration)*time.Second, time.Duration(benchmarkTimeout)*time.Second)
+
+		if fd != nil {
+			b.FaultDetector = fd
+		}
 
 		results := b.Run(ctx)
 


### PR DESCRIPTION
The round subscriber would stop pulling from the rounds and block the reporting of the benchmark (sometimes). This moves the unsubscribe from the round subscriber into the go routine where rounds are being handled so that the eventstream isn't held up.

It also cleans up a lot of repeat logging at the end of a benchmark... though there is still a bunch - this is kind of just a step in the right direction.