### PR TITLE
no-dial-websockets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,10 @@ require (
 	github.com/libp2p/go-libp2p-connmgr v0.1.1
 	github.com/libp2p/go-libp2p-core v0.2.4
 	github.com/libp2p/go-libp2p-pubsub v0.1.1
+	github.com/libp2p/go-libp2p-transport-upgrader v0.1.1
 	github.com/libp2p/go-msgio v0.0.4
+	github.com/libp2p/go-tcp-transport v0.1.1
+	github.com/libp2p/go-ws-transport v0.1.2
 	github.com/multiformats/go-multiaddr v0.1.1
 	github.com/multiformats/go-multiaddr-net v0.1.0
 	github.com/multiformats/go-multihash v0.0.8

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/quorumcontrol/chaintree v1.0.2-0.20200124091942-25ceb93627b9
 	github.com/quorumcontrol/messages v1.1.1
 	github.com/quorumcontrol/messages/v2 v2.1.3-0.20200129115245-2bfec5177653
-	github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200228230624-c8f942c4e131
+	github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200311092327-972eb7d5dd6b
 	github.com/shibukawa/configdir v0.0.0-20170330084843-e180dbdc8da0
 	github.com/spf13/cobra v0.0.5
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -786,6 +786,8 @@ github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200227184332-a1d02e8ba5f
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200227184332-a1d02e8ba5f0/go.mod h1:0fDHOrkzj1T5VDMjh4K3Y1btiRRevBl/zMPuDAf3ZDg=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200228230624-c8f942c4e131 h1:5x1t8Zwm6UmWQ35t36K0O1HNBdOCAB097A6W3j0miis=
 github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200228230624-c8f942c4e131/go.mod h1:dTfjHZCpStx8eAXAzwOEhtQUP7nDCEcfYPpWBCPowKc=
+github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200311092327-972eb7d5dd6b h1:NcU2Js5KsA0TEkXk8d5QqqaPIXwWhtrSLZqFHw0ObPM=
+github.com/quorumcontrol/tupelo-go-sdk v0.6.0-beta1.0.20200311092327-972eb7d5dd6b/go.mod h1:q5zktXYXHK7wOvDDxiJQ20L5+0GOGUKY+cqWBp3hJhg=
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0 h1:RR9dF3JtopPvtkroDZuVD7qquD0bnHlKSqaQhgwt8yk=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=

--- a/nodebuilder/no_dial_websocket.go
+++ b/nodebuilder/no_dial_websocket.go
@@ -1,0 +1,27 @@
+package nodebuilder
+
+import (
+	tptu "github.com/libp2p/go-libp2p-transport-upgrader"
+	ws "github.com/libp2p/go-ws-transport"
+	ma "github.com/multiformats/go-multiaddr"
+)
+
+// NoDialWebSocketTransport is a thin wrapper around the websocket transport
+// but does not allow actually *dialing* the peer
+type NoDialWebSocketTransport struct {
+	*ws.WebsocketTransport
+}
+
+// NewNoDialWebsocketTransport wraps the standard go-ws-transport New to return the non-dialing version
+func NewNoDialWebsocketTransport(u *tptu.Upgrader) *NoDialWebSocketTransport {
+	wsTransport := ws.New(u)
+	return &NoDialWebSocketTransport{
+		WebsocketTransport: wsTransport,
+	}
+}
+
+// CanDial always returns false because for this transport we want to allow connections
+// but *never* want to dial out to the websockets
+func (ndwst *NoDialWebSocketTransport) CanDial(a ma.Multiaddr) bool {
+	return false
+}

--- a/nodebuilder/nodebuilder.go
+++ b/nodebuilder/nodebuilder.go
@@ -23,6 +23,7 @@ import (
 	circuit "github.com/libp2p/go-libp2p-circuit"
 	connmgr "github.com/libp2p/go-libp2p-connmgr"
 	"github.com/libp2p/go-libp2p-core/peer"
+	tcp "github.com/libp2p/go-tcp-transport"
 	"github.com/shibukawa/configdir"
 )
 
@@ -293,6 +294,7 @@ func (nb *NodeBuilder) ownPeerID() (peer.ID, error) {
 
 func (nb *NodeBuilder) defaultP2POptions(ctx context.Context) []p2p.Option {
 	opts := []p2p.Option{
+		p2p.WithTransports(libp2p.Transport(tcp.NewTCPTransport), libp2p.Transport(NewNoDialWebsocketTransport)),
 		p2p.WithDiscoveryNamespaces(nb.Config.NotaryGroupConfig.ID),
 		p2p.WithListenIP("0.0.0.0", nb.Config.Port),
 		p2p.WithBitswapOptions(bitswap.ProvideEnabled(false)),


### PR DESCRIPTION
This relies on https://github.com/quorumcontrol/tupelo-go-sdk/pull/208 to allow configurable transports.

We noticed that SSL wasn't always updating fast enough for the benchmark network to keep up which would cause signers to connect to "incorrect" peers. This turns of *dialing* from the websocket connection on the signers.

I'm pretty sure this is the behavior we want whether or not SSL could keep up though - we don't want these signers sending stuff over websockets rather than TCP. My very first benchmark showed an improvement - full suite running now.