### PR TITLE
small refactor to fix a race

### DIFF
--- a/gossip/node.go
+++ b/gossip/node.go
@@ -140,11 +140,14 @@ func NewNode(ctx context.Context, opts *NewNodeOptions) (*Node, error) {
 	n.snowballer = networkedSnowball
 
 	n.stateStorer = newStateStorer(logger, n.dagStore)
+	n.pubsub = n.p2pNode.GetPubSub()
 
 	return n, nil
 }
 
 func (n *Node) Start(ctx context.Context) error {
+	n.startCtx = ctx
+
 	pid, err := n.rootContext.SpawnNamed(actor.PropsFromFunc(n.Receive), n.name)
 	if err != nil {
 		return fmt.Errorf("error starting actor: %w", err)
@@ -157,59 +160,6 @@ func (n *Node) Start(ctx context.Context) error {
 		<-ctx.Done()
 		n.logger.Infof("node stopped")
 		n.rootContext.Poison(n.pid)
-	}()
-
-	validator, err := NewTransactionValidator(ctx, n.logger, n.notaryGroup, pid)
-	if err != nil {
-		return fmt.Errorf("error setting up: %v", err)
-	}
-	n.validator = validator
-
-	n.pubsub = n.p2pNode.GetPubSub()
-
-	err = n.pubsub.RegisterTopicValidator(n.notaryGroup.Config().TransactionTopic, validator.validate)
-	if err != nil {
-		return fmt.Errorf("error registering topic validator: %v", err)
-	}
-
-	sub, err := n.pubsub.Subscribe(n.notaryGroup.Config().TransactionTopic)
-	if err != nil {
-		return fmt.Errorf("error subscribing %v", err)
-	}
-
-	n.startCtx = ctx
-
-	// don't do anything with these messages because we actually get them
-	// fully decoded in the actor spun up above
-	go func() {
-		for {
-			_, err := sub.Next(ctx)
-			if err != nil {
-				n.logger.Warningf("error getting sub message: %v", err)
-				return
-			}
-		}
-	}()
-
-	go func() {
-		// every once in a while check to see if the mempool has entries and if the
-		// snowballer has started and start the snowballer if it isn't
-		// this is handled by the snowball actor spun up in the node's root actor (see: Receive function)
-		checkSnowballTicker := time.NewTicker(200 * time.Millisecond)
-		republishTicker := time.NewTicker(500 * time.Millisecond)
-		ctxDone := ctx.Done()
-		for {
-			select {
-			case <-ctxDone:
-				checkSnowballTicker.Stop()
-				republishTicker.Stop()
-				return
-			case <-checkSnowballTicker.C:
-				n.maybeStartSnowball(ctx)
-			case <-republishTicker.C:
-				n.maybeRepublish(ctx)
-			}
-		}
 	}()
 
 	n.logger.Debugf("node starting")
@@ -279,6 +229,72 @@ func (n *Node) setupStateStorer(actorContext actor.Context) {
 	n.stateStorerPid = storerPid
 }
 
+func (n *Node) setupValidation(actorContext actor.Context) error {
+	ctx := n.startCtx
+
+	validator, err := NewTransactionValidator(ctx, n.logger, n.notaryGroup, actorContext.Self())
+	if err != nil {
+		return fmt.Errorf("error setting up: %v", err)
+	}
+	n.validator = validator
+
+	err = n.pubsub.RegisterTopicValidator(n.notaryGroup.Config().TransactionTopic, validator.validate)
+	if err != nil {
+		return fmt.Errorf("error registering topic validator: %v", err)
+	}
+
+	return nil
+}
+
+func (n *Node) subscribeToTransactions() error {
+	sub, err := n.pubsub.Subscribe(n.notaryGroup.Config().TransactionTopic)
+	if err != nil {
+		return fmt.Errorf("error subscribing %v", err)
+	}
+
+	// don't do anything with these messages because we actually get them
+	// from the topic validator which sends them in fully decoded to the
+	// node main actor
+	go func() {
+		ctx := n.startCtx
+
+		for {
+			_, err := sub.Next(ctx)
+			if err != nil {
+				n.logger.Warningf("error getting sub message: %v", err)
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (n *Node) setupTickers() {
+	go func() {
+		ctx := n.startCtx
+		// every once in a while check to see if the mempool has entries and if the
+		// snowballer has started and start the snowballer if it isn't
+		// this is handled by the snowball actor spun up in the node's root actor (see: Receive function)
+		checkSnowballTicker := time.NewTicker(200 * time.Millisecond)
+		republishTicker := time.NewTicker(500 * time.Millisecond)
+		ctxDone := ctx.Done()
+		for {
+			select {
+			case <-ctxDone:
+				checkSnowballTicker.Stop()
+				republishTicker.Stop()
+				return
+			case <-checkSnowballTicker.C:
+				n.maybeStartSnowball(ctx)
+			case <-republishTicker.C:
+				n.maybeRepublish(ctx)
+			}
+		}
+	}()
+
+}
+
 func (n *Node) setupSyncer(actorContext actor.Context) {
 	syncerPid, err := actorContext.SpawnNamed(actor.PropsFromProducer(func() actor.Actor {
 		return &transactionGetter{
@@ -297,9 +313,16 @@ func (n *Node) setupSyncer(actorContext actor.Context) {
 func (n *Node) Receive(actorContext actor.Context) {
 	switch msg := actorContext.Message().(type) {
 	case *actor.Started:
+		if err := n.setupValidation(actorContext); err != nil {
+			panic(err)
+		}
 		n.setupSyncer(actorContext)
 		n.setupSnowball(actorContext)
 		n.setupStateStorer(actorContext)
+		n.setupTickers()
+		if err := n.subscribeToTransactions(); err != nil {
+			panic(err)
+		}
 	case *AddBlockWrapper:
 		n.handleAddBlockRequest(actorContext, msg)
 	case *snowballerDone:

--- a/gossip/txsyncer.go
+++ b/gossip/txsyncer.go
@@ -40,6 +40,7 @@ func (tg *transactionGetter) Receive(actorContext actor.Context) {
 		err := tg.store.Get(ctx, msg, abr)
 		if err != nil {
 			tg.logger.Warningf("error fetching %s", msg.String())
+			return
 		}
 
 		tg.cache.Add(msg.String(), struct{}{})


### PR DESCRIPTION
from chat:
```
node1_1      | [ACTOR] Recovering actor="nonhost/node-9/transactionsyncer" reason="runtime error: invalid memory address or nil pointer dereference" stacktrace="github.com/quorumcontrol/tupelo/gossip.(*TransactionValidator).ValidateAbr:152" 
node1_1      | [SUPERVISION] actor="nonhost/node-9/transactionsyncer" directive="RestartDirective" reason="runtime error: invalid memory address or nil pointer dereference"
```

https://github.com/quorumcontrol/tupelo/blob/master/gossip/node.go#L148
which calls https://github.com/quorumcontrol/tupelo/blob/master/gossip/node.go#L300
which can happen before https://github.com/quorumcontrol/tupelo/blob/master/gossip/node.go#L166

This puts more logic into the actual *actor* startup as opposed to the node Start method which eliminates race conditions.