### PR TITLE
expose signer ports in local docker-compose

### DIFF
--- a/configs/localdocker/node0/config.toml
+++ b/configs/localdocker/node0/config.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "../localdocker.toml"
+Port = 34002
 
 [PrivateKeySet]
 SignKeyHex = "0x4344e3372f1b790016ed86400611fab64d0bba91136518685a7ce34106f1c759"

--- a/configs/localdocker/node1/config.toml
+++ b/configs/localdocker/node1/config.toml
@@ -1,5 +1,5 @@
 NotaryGroupConfig = "../localdocker.toml"
-
+Port = 34003
 
 [PrivateKeySet]
 SignKeyHex = "0x39a9b8ab3266811852b8b18d1fd0562ffc907f3ecba297c9b2a89f742d349dc9"

--- a/configs/localdocker/node2/config.toml
+++ b/configs/localdocker/node2/config.toml
@@ -1,4 +1,5 @@
 NotaryGroupConfig = "../localdocker.toml"
+Port = 34004
 
 [PrivateKeySet]
 SignKeyHex = "0x558a546adacea3d761741bf4a6415ef2eeb85bfa457036b59564fa88ee276cf5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,8 @@ services:
       - ./configs/localdocker:/configs
     command: ["node", "--config", "/configs/node0/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
+    ports:
+      - "34002:34002"
 
   node1:
     depends_on: 
@@ -41,6 +43,8 @@ services:
       - ./configs/localdocker:/configs
     command: ["node", "--config", "/configs/node1/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
+    ports:
+      - "34003:34003"
   
   node2:
     depends_on: 
@@ -50,6 +54,8 @@ services:
       - ./configs/localdocker:/configs
     command: ["node", "--config", "/configs/node2/config.toml",
       "-L", "${TUPELO_LOG_LEVEL:-info}"]
+    ports:
+      - "34004:34004"
 
 networks:
   default:


### PR DESCRIPTION
In local testing, relying on bootstrap to relay caused tests from local machine to signers to fail frequently.  Given https://github.com/quorumcontrol/tupelo/pull/439 is on the horizon too, this updates the signers to also expose their port to the host machine