### PR TITLE
Feature/benchmark classification

### DIFF
--- a/metrics/classifier/default.go
+++ b/metrics/classifier/default.go
@@ -36,5 +36,11 @@ func Default(ctx context.Context, startDag *dag.Dag, endDag *dag.Dag) (classific
 		classification = "dgit"
 	}
 
+	if doctype, ok := dataMap["__doctype"]; ok {
+		if doctypstr, ok := doctype.(string); ok {
+			classification = doctypstr
+		}
+	}
+
 	return
 }


### PR DESCRIPTION
As a follow up to https://github.com/quorumcontrol/tupelo/pull/460, this adds a generic `__doctype` field that metrics can use to auto-classify. The first use case of that is the benchmarker chaintrees.

Also makes the payloads for the benchmarker a _bit_ randomized.