### PR TITLE
fix tupelo wasm client which was just missing a namespace

### DIFF
--- a/sdk/wasm/jsclient/jsclient.go
+++ b/sdk/wasm/jsclient/jsclient.go
@@ -56,7 +56,7 @@ func New(pubsub pubsubinterfaces.Pubsubber, humanConfig *config.NotaryGroup, sto
 		panic(errors.Wrap(err, "error getting notary group from config"))
 	}
 
-	cli := client.New(WithNotaryGroup(ng), WithPubsub(pubsub), WithDagStore(store))
+	cli := client.New(client.WithNotaryGroup(ng), client.WithPubsub(pubsub), client.WithDagStore(store))
 
 	return &JSClient{
 		client:      cli,


### PR DESCRIPTION
When moving the tupelo-wasm-sdk over to the new repo noticed that we were missing the package name for these functional options.