### PR TITLE
test fixes

### DIFF
--- a/signer/gossip/mempool.go
+++ b/signer/gossip/mempool.go
@@ -19,20 +19,11 @@ type conflictSet struct {
 }
 
 func (cs *conflictSet) Add(id cid.Cid) {
-	var preferred cid.Cid
-	newCIDString := id.String()
-	for _, existingID := range cs.ids {
-		if newCIDString < existingID.String() {
-			preferred = id
-		}
-	}
-
-	if preferred.Equals(cid.Undef) {
-		preferred = id
-	}
-
 	cs.ids = append(cs.ids, id)
-	cs.preferred = preferred
+
+	if cs.preferred.Equals(cid.Undef) || id.String() < cs.preferred.String() {
+		cs.preferred = id
+	}
 }
 
 type mempool struct {

--- a/signer/nodebuilder/config.go
+++ b/signer/nodebuilder/config.go
@@ -23,7 +23,10 @@ const (
 )
 
 type Config struct {
+	// @deprecated - I can't find anywhere using Namespace
 	Namespace string
+
+	NodeName string
 
 	NotaryGroupConfig *types.Config
 	PublicIP          string

--- a/signer/nodebuilder/nodebuilder.go
+++ b/signer/nodebuilder/nodebuilder.go
@@ -192,6 +192,7 @@ func (nb *NodeBuilder) startSigner(ctx context.Context) (*p2p.LibP2PHost, error)
 	nb.host = p2pNode
 
 	nodeCfg := &gossip.NewNodeOptions{
+		Name:        nb.Config.NodeName,
 		P2PNode:     p2pNode,
 		SignKey:     localKeys.SignKey,
 		NotaryGroup: group,

--- a/signer/nodebuilder/nodebuilder_test.go
+++ b/signer/nodebuilder/nodebuilder_test.go
@@ -55,11 +55,11 @@ func TestSigner(t *testing.T) {
 		ngConfig := types.DefaultConfig()
 		ngConfig.ID = "hardcoded"
 		ngConfig.Signers = []types.PublicKeySet{
-			types.PublicKeySet{
+			{
 				DestKey: &ts.EcdsaKeys[1].PublicKey,
 				VerKey:  ts.SignKeys[1].MustVerKey(),
 			},
-			types.PublicKeySet{
+			{
 				DestKey: &ts.EcdsaKeys[2].PublicKey,
 				VerKey:  ts.SignKeys[2].MustVerKey(),
 			},
@@ -74,6 +74,7 @@ func TestSigner(t *testing.T) {
 
 		nb := &NodeBuilder{
 			Config: &Config{
+				NodeName:          "TestSignerBasicConfig",
 				NotaryGroupConfig: ngConfig,
 				PrivateKeySet: &PrivateKeySet{
 					DestKey: ts.EcdsaKeys[0],


### PR DESCRIPTION
This fixes two problems we've seen in the tests:

* The *state* section of an AddBlockRequest (ABR) is non-deterministic because we add state nodes there and so sometimes an abr will have a higher hash than the other. This lets the *test* figure that out so it knows what to assert.

* Occasionally an old node doesn't shut down before the next test starts up. This lets a nodebuilder config have a name (that's currently only used in a test).


On an aside I noticed a Namesapce in nodebuilder config that I didn't see used anywhere so I just marked it deprecated for now.