### PR TITLE
make isOwner usable inside Client

### DIFF
--- a/sdk/gossip/client/client.go
+++ b/sdk/gossip/client/client.go
@@ -87,7 +87,7 @@ func NewWithConfig(ctx context.Context, config *Config) (*Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Client{
+	cli := &Client{
 		Group:        config.Group,
 		logger:       config.Logger,
 		pubsub:       config.Pubsub,
@@ -96,7 +96,13 @@ func NewWithConfig(ctx context.Context, config *Config) (*Client, error) {
 		transactors:  config.Transactors,
 		subscriber:   config.subscriber,
 		onStartHooks: config.OnStartHooks,
-	}, nil
+	}
+
+	if cli.Group.DagGetter == nil {
+		cli.Group.DagGetter = types.NewClientDagGetter(cli)
+	}
+
+	return cli, nil
 }
 
 func (c *Client) DagStore() nodestore.DagStore {

--- a/sdk/gossip/client/client_test.go
+++ b/sdk/gossip/client/client_test.go
@@ -126,8 +126,6 @@ func newClient(ctx context.Context, group *types.NotaryGroup, bootAddrs []string
 		return nil, err
 	}
 
-	group.DagGetter = types.NewClientDagGetter(cli)
-
 	return cli, nil
 }
 

--- a/sdk/gossip/types/validators.go
+++ b/sdk/gossip/types/validators.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/ipfs/go-cid"
 
-	"github.com/quorumcontrol/chaintree/graftabledag"
 	"github.com/quorumcontrol/chaintree/typecaster"
 
 	"github.com/quorumcontrol/tupelo/sdk/consensus"
@@ -184,16 +183,13 @@ func HasBurnGenerator(ctx context.Context, ng *NotaryGroup) (chaintree.BlockVali
 // of this or any owning chaintree, or any other path that resolves to owner key addrs) has signed
 // this block.
 func IsOwnerGenerator(ctx context.Context, ng *NotaryGroup) (chaintree.BlockValidatorFunc, error) {
-	dagGetter := ng.DagGetter
-
 	var isOwnerValidator chaintree.BlockValidatorFunc = func(tree *dag.Dag, blockWithHeaders *chaintree.BlockWithHeaders) (bool, chaintree.CodedError) {
-		return isOwner(ctx, dagGetter, tree, blockWithHeaders)
+		return isOwner(ctx, ng, tree, blockWithHeaders)
 	}
-
 	return isOwnerValidator, nil
 }
 
-func isOwner(ctx context.Context, dagGetter graftabledag.DagGetter, tree *dag.Dag, blockWithHeaders *chaintree.BlockWithHeaders) (bool, chaintree.CodedError) {
+func isOwner(ctx context.Context, ng *NotaryGroup, tree *dag.Dag, blockWithHeaders *chaintree.BlockWithHeaders) (bool, chaintree.CodedError) {
 	headers := &consensus.StandardHeaders{}
 
 	err := typecaster.ToType(blockWithHeaders.Headers, headers)
@@ -201,7 +197,7 @@ func isOwner(ctx context.Context, dagGetter graftabledag.DagGetter, tree *dag.Da
 		return false, &consensus.ErrorCode{Memo: fmt.Sprintf("error: %v", err), Code: consensus.ErrUnknown}
 	}
 
-	gro, err := NewGraftedOwnership(tree, dagGetter)
+	gro, err := NewGraftedOwnership(tree, ng.DagGetter)
 	if err != nil {
 		return false, &consensus.ErrorCode{Memo: fmt.Sprintf("error creating GraftedOwnership: %v", err), Code: consensus.ErrUnknown}
 	}


### PR DESCRIPTION
This ensures that `client.New` & `client.NewWithOptions` automatically set the `NotaryGroup.DagGetter` to itself if not yet set. Also had to update `isOwner` to pass through `NotaryGroup` pointer instead because `DagGetter` is set after the validators are generated.