### PR TITLE
remove replaying transactions on GetLatest

### DIFF
--- a/sdk/gossip/client/client_test.go
+++ b/sdk/gossip/client/client_test.go
@@ -521,6 +521,9 @@ func TestGetLatest(t *testing.T) {
 		// get the tree using cli2 and make sure you can resolve the data
 		cli2Tree, err := cli2.GetLatest(ctx, tree.MustId())
 		require.Nil(t, err)
+
+		require.Equal(t, proof.Tip, cli2Tree.Tip().Bytes())
+
 		resp, remain, err := cli2Tree.ChainTree.Dag.Resolve(ctx, strings.Split("tree/data/"+path, "/"))
 		t.Logf("remain: %v", remain)
 		require.Nil(t, err)


### PR DESCRIPTION
We used to have all the state needed to replay transactions locally in order to reproduce state. However, graftable ownership has changed this and now there might be remote state needed. We don't actually *need* to do this anyway: https://github.com/quorumcontrol/tupelo/blob/bug/remove-playing/sdk/gossip/client/processblocks.go since now the new blocks are part of the state and just getting the latest will work.